### PR TITLE
feat: add gpx file input

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
 </head>
 <body style="margin:0;">
 <canvas id="app"></canvas>
+<input id="gpx" type="file" accept=".gpx" style="position:fixed;top:12px;left:12px;z-index:10" />
 <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 "name": "rouelibre",
-"version": "0.1.0",
+"version": "0.1.1",
 "private": true,
 "type": "module",
 "scripts": {


### PR DESCRIPTION
## Summary
- add fixed-position GPX file input overlaying the Three.js canvas
- bump package version to 0.1.1

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run lint` *(fails: Missing script "lint"*)
- `npm run check` *(fails: TS2307 Cannot find module 'three', TS2304 Cannot find name 'init', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a89f580e748329b23fbe6d0ad62c8a