### PR TITLE
Simplify GPX path and add road controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,11 @@
 <body style="margin:0;">
 <canvas id="app"></canvas>
 <input id="gpx" type="file" accept=".gpx" style="position:fixed;top:12px;left:12px;z-index:10" />
+<div id="controls" style="position:fixed;top:50px;left:12px;z-index:10;background:rgba(0,0,0,0.4);padding:4px;color:white;font:12px sans-serif;">
+  <label>Route <input id="roadWidth" type="number" value="6" step="0.1" style="width:60px" /></label><br />
+  <label>Dash <input id="dashLength" type="number" value="3" step="0.1" style="width:60px" /></label><br />
+  <label>Gap <input id="gapLength" type="number" value="5" step="0.1" style="width:60px" /></label>
+</div>
 <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 "name": "rouelibre",
-  "version": "0.1.2",
+  "version": "0.1.3",
 "private": true,
 "type": "module",
 "scripts": {


### PR DESCRIPTION
## Summary
- apply Douglas–Peucker simplification to GPX path before building road
- add fixed UI panel to tweak road width and dash/gap lengths
- bump package version

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Could not find a declaration file for module 'three'; missing names in worker)*

------
https://chatgpt.com/codex/tasks/task_b_68a8bf554e408329aa6e69feda721b78