### PR TITLE
Display version number on screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-"name": "rouelibre",
-  "version": "0.1.2",
-"private": true,
-"type": "module",
-"scripts": {
-"dev": "vite",
-"build": "vite build",
-"preview": "vite preview --strictPort --port 4173",
-"check": "tsc --noEmit"
-},
-"dependencies": {
-"@dimforge/rapier3d-compat": "^0.13.1",
-"three": "^0.168.0"
-},
-"devDependencies": {
-"typescript": "^5.5.4",
-"vite": "^5.4.0"
-}
+  "name": "rouelibre",
+  "version": "0.1.3",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --strictPort --port 4173",
+    "check": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@dimforge/rapier3d-compat": "^0.13.1",
+    "three": "^0.168.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vite": "^5.4.0"
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 // src/main.ts
 import * as THREE from 'three'
+import pkg from '../package.json'
 
 const N = 184 // nombre de cyclistes
 
@@ -8,6 +9,19 @@ const canvas = document.getElementById('app') as HTMLCanvasElement
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
 renderer.setSize(window.innerWidth, window.innerHeight)
+
+const versionEl = document.createElement('div')
+versionEl.textContent = `v${pkg.version}`
+versionEl.style.position = 'fixed'
+versionEl.style.bottom = '8px'
+versionEl.style.left = '50%'
+versionEl.style.transform = 'translateX(-50%)'
+versionEl.style.color = '#fff'
+versionEl.style.fontFamily = 'sans-serif'
+versionEl.style.fontSize = '14px'
+versionEl.style.zIndex = '10'
+versionEl.style.pointerEvents = 'none'
+document.body.appendChild(versionEl)
 
 // Scene & Camera
 const scene = new THREE.Scene()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,18 @@
 {
 "compilerOptions": {
 "target": "ES2020",
-"module": "ESNext",
-"moduleResolution": "Bundler",
-"lib": ["ES2020", "DOM", "WebWorker"],
-"strict": true,
-"jsx": "react-jsx",
-"noEmit": true,
-"types": [],
-"skipLibCheck": true,
-"forceConsistentCasingInFileNames": true,
-"baseUrl": ".",
-"paths": {}
+  "module": "ESNext",
+  "moduleResolution": "Bundler",
+  "lib": ["ES2020", "DOM", "WebWorker"],
+  "strict": true,
+  "jsx": "react-jsx",
+  "noEmit": true,
+  "types": [],
+  "skipLibCheck": true,
+  "forceConsistentCasingInFileNames": true,
+  "baseUrl": ".",
+  "paths": {},
+  "resolveJsonModule": true
 },
 "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- show application version at the bottom center by importing package.json
- enable JSON module resolution in TypeScript config
- bump package version to 0.1.3

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run check` *(fails: Could not find a declaration file for module 'three'; Cannot find name 'init'; Cannot find name 'world'; Cannot find name 'RAPIER'; Cannot find name 'N'; Cannot find name 'positions'; Cannot find name 'bodies'; Cannot find name 'speeds')*

------
https://chatgpt.com/codex/tasks/task_b_68a8bf5f4ed08329936029ba7623890c