### PR TITLE
Add test and lint npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
-"name": "rouelibre",
-  "version": "0.1.2",
-"private": true,
-"type": "module",
-"scripts": {
-"dev": "vite",
-"build": "vite build",
-"preview": "vite preview --strictPort --port 4173",
-"check": "tsc --noEmit"
-},
-"dependencies": {
-"@dimforge/rapier3d-compat": "^0.13.1",
-"three": "^0.168.0"
-},
-"devDependencies": {
-"typescript": "^5.5.4",
-"vite": "^5.4.0"
-}
+  "name": "rouelibre",
+  "version": "0.1.3",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview --strictPort --port 4173",
+    "check": "tsc --noEmit",
+    "test": "node test/relayCluster.test.js && echo \"tests completed\"",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@dimforge/rapier3d-compat": "^0.13.1",
+    "three": "^0.168.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "vite": "^5.4.0"
+  }
 }

--- a/test/relayCluster.test.js
+++ b/test/relayCluster.test.js
@@ -1,0 +1,1 @@
+console.log('relayCluster test placeholder');


### PR DESCRIPTION
## Summary
- add placeholder test and lint scripts in package.json
- add minimal relayCluster test file

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_b_68a8bf8974f08329a8a2398694fdd806