### PR TITLE
Declare physics worker variables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/physics/worker.ts
+++ b/src/physics/worker.ts
@@ -1,11 +1,19 @@
 // Worker Rapier : met à jour les positions et renvoie un Float32Array transférable
+import init, * as RAPIER from '@dimforge/rapier3d-compat'
+
+let world: RAPIER.World
+let N = 0
+let positions: Float32Array
+let bodies: RAPIER.RigidBody[]
+let speeds: Float32Array
+
 function mulberry32(a: number) {
-return function () {
-let t = (a += 0x6d2b79f5)
-t = Math.imul(t ^ (t >>> 15), t | 1)
-t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
-return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-}
+  return function () {
+    let t = (a += 0x6d2b79f5)
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
 }
 
 

--- a/test/relayCluster.test.js
+++ b/test/relayCluster.test.js
@@ -1,1 +1,0 @@
-console.log('relayCluster test placeholder');

--- a/test/relayCluster.test.ts
+++ b/test/relayCluster.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('relayCluster', () => {
+  it('placeholder test', () => {
+    expect(1 + 1).toBe(2)
+  })
+})


### PR DESCRIPTION
## Summary
- import Rapier and declare physics worker state variables
- add placeholder unit test for relay cluster
- bump version to 0.1.4

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a8c732a1748329b2c3647c6781b1f2