### PR TITLE
Fix duplicate physics worker declarations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/physics/worker.ts
+++ b/src/physics/worker.ts
@@ -7,13 +7,6 @@ let bodies: RAPIER.RigidBody[] = []
 let speeds: Float32Array
 
 // Worker Rapier : met à jour les positions et renvoie un Float32Array transférable
-import RAPIER, { init } from '@dimforge/rapier3d-compat'
-
-let world: RAPIER.World
-let positions: Float32Array
-let bodies: RAPIER.RigidBody[]
-let speeds: Float32Array
-let N: number
 
 function mulberry32(a: number) {
   return function () {
@@ -26,74 +19,74 @@ function mulberry32(a: number) {
 
 
 self.onmessage = async (e: MessageEvent) => {
-const { type, payload }: { type: string; payload: any } = e.data || {}
-
+  const { type, payload }: { type: string; payload: any } = e.data || {}
 
   if (type === 'init') {
-  await (init as unknown as () => Promise<void>)() // charge le WASM
-world = new RAPIER.World({ x: 0, y: 0, z: 0 }) // pas de gravité pour commencer
+    await (init as unknown as () => Promise<void>)() // charge le WASM
+    world = new RAPIER.World({ x: 0, y: 0, z: 0 }) // pas de gravité pour commencer
 
+    N = payload.N as number
+    const initial = new Float32Array(payload.positions)
+    positions = new Float32Array(N * 3)
+    positions.set(initial)
 
-N = payload.N as number
-const initial = new Float32Array(payload.positions)
-positions = new Float32Array(N * 3)
-positions.set(initial)
+    // corps cinématiques (on contrôle la translation)
+    bodies = new Array(N)
+    const rng = mulberry32(123456)
+    speeds = new Float32Array(N)
 
+    for (let i = 0; i < N; i++) {
+      const bd = RAPIER.RigidBodyDesc.kinematicPositionBased()
+      const rb = world.createRigidBody(bd)
+      // largeur/hauteur/profondeur proches du rendu
+      const cd = RAPIER.ColliderDesc.cuboid(0.25, 0.85, 0.5)
+      world.createCollider(cd, rb)
+      rb.setTranslation(
+        { x: initial[i * 3 + 0], y: initial[i * 3 + 1], z: initial[i * 3 + 2] },
+        true
+      )
+      bodies[i] = rb
+      // vitesse de base + petite variance (m/s)
+      speeds[i] = 7.0 + rng() * 1.0 // ~25–29 km/h pour démo
+    }
 
-// corps cinématiques (on contrôle la translation)
-bodies = new Array(N)
-const rng = mulberry32(123456)
-speeds = new Float32Array(N)
+    // premier envoi
+    ;(self as unknown as Worker).postMessage(
+      { type: 'state', data: positions.buffer },
+      [positions.buffer]
+    )
+  }
 
+  if (type === 'step') {
+    const dt: number = payload.dt
 
-for (let i = 0; i < N; i++) {
-const bd = RAPIER.RigidBodyDesc.kinematicPositionBased()
-const rb = world.createRigidBody(bd)
-// largeur/hauteur/profondeur proches du rendu
-const cd = RAPIER.ColliderDesc.cuboid(0.25, 0.85, 0.5)
-world.createCollider(cd, rb)
-rb.setTranslation({ x: initial[i * 3 + 0], y: initial[i * 3 + 1], z: initial[i * 3 + 2] }, true)
-bodies[i] = rb
-// vitesse de base + petite variance (m/s)
-speeds[i] = 7.0 + rng() * 1.0 // ~25–29 km/h pour démo
-}
+    // simple logique : avance sur +X avec légère ondulation en Z
+    for (let i = 0; i < N; i++) {
+      const rb = bodies[i]
+      const cur = rb.translation()
+      const speed = speeds[i]
+      const nx = cur.x + speed * dt
+      const nz =
+        cur.z + Math.sin((cur.x + i * 0.1) * 0.2) * 0.02 // micro oscillation
+      rb.setNextKinematicTranslation({ x: nx, y: 0.85, z: nz })
+    }
 
+    world.step()
 
-// premier envoi
-;(self as unknown as Worker).postMessage({ type: 'state', data: positions.buffer }, [positions.buffer])
-}
+    // remplir le buffer positions
+    for (let i = 0; i < N; i++) {
+      const t = bodies[i].translation()
+      positions[i * 3 + 0] = t.x
+      positions[i * 3 + 1] = t.y
+      positions[i * 3 + 2] = t.z
+    }
 
-
-if (type === 'step') {
-const dt: number = payload.dt
-
-
-// simple logique : avance sur +X avec légère ondulation en Z
-for (let i = 0; i < N; i++) {
-const rb = bodies[i]
-const cur = rb.translation()
-const speed = speeds[i]
-const nx = cur.x + speed * dt
-const nz = cur.z + Math.sin((cur.x + i * 0.1) * 0.2) * 0.02 // micro oscillation
-rb.setNextKinematicTranslation({ x: nx, y: 0.85, z: nz })
-}
-
-
-world.step()
-
-
-// remplir le buffer positions
-for (let i = 0; i < N; i++) {
-const t = bodies[i].translation()
-positions[i * 3 + 0] = t.x
-positions[i * 3 + 1] = t.y
-positions[i * 3 + 2] = t.z
-}
-
-
-// transférer le buffer (zéro copie)
-;(self as unknown as Worker).postMessage({ type: 'state', data: positions.buffer }, [positions.buffer])
-// recréer un buffer côté worker (car transféré)
-positions = new Float32Array(N * 3)
-}
+    // transférer le buffer (zéro copie)
+    ;(self as unknown as Worker).postMessage(
+      { type: 'state', data: positions.buffer },
+      [positions.buffer]
+    )
+    // recréer un buffer côté worker (car transféré)
+    positions = new Float32Array(N * 3)
+  }
 }


### PR DESCRIPTION
## Summary
- remove duplicate Rapier imports and variable declarations in physics worker
- ignore node_modules and bump package version

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config file)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a8ca94edac8329aeb2cea2b32545a5