### PR TITLE
fix: include vite type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
   "strict": true,
   "jsx": "react-jsx",
   "noEmit": true,
-  "types": ["three"],
+  "types": ["three", "vite/client"],
   "skipLibCheck": true,
   "forceConsistentCasingInFileNames": true,
   "baseUrl": ".",


### PR DESCRIPTION
## Summary
- include `vite/client` type definitions so `import.meta.glob` is recognized
- bump version to 0.1.11

## Testing
- `npm run check`
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a97bac7ca08329912701d6bfce8d28