### PR TITLE
Use manifest to list GPX routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.8",
+  "version": "0.1.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.8",
+      "version": "0.1.12",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/ui/routeSelector.ts
+++ b/src/ui/routeSelector.ts
@@ -6,11 +6,15 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
   const container = document.getElementById(containerId)
   if (!container) return
 
-  const modules = import.meta.glob('/gpx/*.gpx', { as: 'url', eager: true })
-  const files = Object.entries(modules).map(([path, url]) => ({
-    name: path.split('/').pop()!,
-    url: url as string,
-  }))
+  const res = await fetch('/gpx/index.json')
+  const files: { name: string; url: string }[] = await res.json()
+
+  if (!files.length) {
+    const empty = document.createElement('div')
+    empty.textContent = 'Aucun parcours trouvé'
+    container.appendChild(empty)
+    return
+  }
 
   for (const file of files) {
     const item = document.createElement('div')


### PR DESCRIPTION
## Summary
- Fetch route list from `/gpx/index.json` instead of using `import.meta.glob`
- Show “Aucun parcours trouvé” when no routes exist
- Bump version to 0.1.12

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a97ebfc8d08329a3afdcdc1de2aaf4