### PR TITLE
Add GPX routes manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Roue libre
 Simulation de cyclisme
 
+> Ajouter toute nouvelle route dans `public/gpx/index.json`.
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/gpx/index.json
+++ b/public/gpx/index.json
@@ -1,0 +1,4 @@
+[
+  { "name": "route1.gpx", "url": "/gpx/route1.gpx" },
+  { "name": "route2.gpx", "url": "/gpx/route2.gpx" }
+]


### PR DESCRIPTION
## Summary
- add `public/gpx/index.json` listing available GPX routes
- remind contributors in README to update the manifest when adding routes
- bump version to 0.1.13

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68a97fabf2b883299d2502c5ed34566b