### PR TITLE
Fix invisible controls on initial load

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,16 @@
 </head>
 <body class="m-0">
 <canvas id="app"></canvas>
-<div id="route-list" class="fixed top-3 left-3 z-10 bg-black/40 p-1 text-white text-xs font-sans"></div>
-<div id="controls" class="fixed top-12 left-3 z-10 bg-black/40 p-1 text-white text-xs font-sans">
+<div
+  id="route-list"
+  style="position:fixed;top:0.75rem;left:0.75rem;z-index:10;"
+  class="fixed top-3 left-3 z-10 bg-black/40 p-1 text-white text-xs font-sans"
+></div>
+<div
+  id="controls"
+  style="position:fixed;top:3rem;left:0.75rem;z-index:10;"
+  class="fixed top-12 left-3 z-10 bg-black/40 p-1 text-white text-xs font-sans"
+>
   <label>Route <input id="roadWidth" type="number" value="6" step="0.1" class="w-16" /></label><br />
   <label>Dash <input id="dashLength" type="number" value="3" step="0.1" class="w-16" /></label><br />
   <label>Gap <input id="gapLength" type="number" value="5" step="0.1" class="w-16" /></label>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- ensure route and control elements are positioned with inline styles so they appear as soon as the page loads
- bump version to 0.1.17

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a9842e93548329b53987ed9465f5df