### PR TITLE
fix: hide canvas overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>Roue libre – Three + Rapier</title>
 </head>
-<body class="m-0">
-<canvas id="app"></canvas>
+<body class="m-0 overflow-hidden">
+<canvas id="app" class="block"></canvas>
 <div
   id="route-list"
   style="position:fixed;top:0.75rem;left:0.75rem;z-index:10;"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- prevent unwanted scrollbars by hiding body overflow
- ensure canvas renders as block element

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9957fca408329b4271348ed8129be