### PR TITLE
style: use utility classes in route selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/ui/routeSelector.ts
+++ b/src/ui/routeSelector.ts
@@ -18,11 +18,11 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
 
   for (const file of files) {
     const item = document.createElement('div')
-    item.style.marginBottom = '8px'
+    item.classList.add('mb-2')
 
     const label = document.createElement('div')
     label.textContent = file.name
-    label.style.marginBottom = '2px'
+    label.classList.add('mb-0.5')
     item.appendChild(label)
 
     container.appendChild(item)
@@ -30,7 +30,7 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
     const resFile = await fetch(file.url)
     if (!resFile.ok) {
       const invalid = document.createElement('div')
-      invalid.style.color = '#f88'
+      invalid.classList.add('text-[#f88]')
       invalid.textContent = 'Fichier invalide'
       item.appendChild(invalid)
       continue
@@ -40,15 +40,14 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
     const points = parseGPX(xmlText)
     if (!points.length) {
       const invalid = document.createElement('div')
-      invalid.style.color = '#f88'
+      invalid.classList.add('text-[#f88]')
       invalid.textContent = 'Fichier invalide'
       item.appendChild(invalid)
       continue
     }
 
     const { path3D } = projectToLocal(points)
-
-    item.style.cursor = 'pointer'
+    item.classList.add('cursor-pointer')
     const canvas = document.createElement('canvas')
     canvas.width = 120
     canvas.height = 40


### PR DESCRIPTION
## Summary
- replace inline styling in route selector with Tailwind utility classes
- bump version to 0.1.19

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a999af97588329a82092ec02c3092c