### PR TITLE
Center route selector and fix relative paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <canvas id="app" class="block"></canvas>
 <div
   id="route-list"
-  class="fixed top-3 left-3 z-10 bg-black/40 p-1 text-white text-xs font-sans"
+  class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 bg-black/40 p-1 text-white text-xs font-sans"
 ></div>
 <div id="loader" class="hidden fixed inset-0 bg-black/70 items-center justify-center z-[100]">
   <div id="loader-bar" class="w-4/5 max-w-[400px] h-3 bg-gray-700">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.20",
+      "version": "0.1.21",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.20",
+  "version": "0.1.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/public/gpx/index.json
+++ b/public/gpx/index.json
@@ -1,4 +1,4 @@
 [
-  { "name": "route1.gpx", "url": "/gpx/route1.gpx" },
-  { "name": "route2.gpx", "url": "/gpx/route2.gpx" }
+  { "name": "route1.gpx", "url": "gpx/route1.gpx" },
+  { "name": "route2.gpx", "url": "gpx/route2.gpx" }
 ]

--- a/src/ui/routeSelector.ts
+++ b/src/ui/routeSelector.ts
@@ -5,8 +5,8 @@ export type RouteSelectCallback = (path: Vec3[], points: GPXPoint[], url: string
 export async function initRouteSelector(containerId: string, onSelect: RouteSelectCallback) {
   const container = document.getElementById(containerId)
   if (!container) return
-
-  const res = await fetch('/gpx/index.json')
+  const base = import.meta.env.BASE_URL
+  const res = await fetch(`${base}gpx/index.json`)
   const files: { name: string; url: string }[] = await res.json()
 
   if (!files.length) {
@@ -27,7 +27,7 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
 
     container.appendChild(item)
 
-    const resFile = await fetch(file.url)
+    const resFile = await fetch(`${base}${file.url}`)
     if (!resFile.ok) {
       const invalid = document.createElement('div')
       invalid.classList.add('text-[#f88]')


### PR DESCRIPTION
## Summary
- center route list overlay
- load route list using relative URLs so routes appear on load
- bump version to 0.1.21

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a99b7ea2d4832992093faf4ab88467