### PR TITLE
Hide route list once GPX is loaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -153,6 +153,14 @@ async function loadGPX(url: string, onProgress: (p: number) => void): Promise<{ 
   return { path3D, points }
 }
 
+function hideRouteList() {
+  document.getElementById('route-list')?.classList.add('hidden')
+}
+
+export function showRouteList() {
+  document.getElementById('route-list')?.classList.remove('hidden')
+}
+
 function rebuildRoute() {
   if (!currentPath) return
   removeIfPresent('routeMesh')
@@ -174,6 +182,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const { path3D, points } = await loadGPX(url, (p) => {
       loaderProgress.style.width = `${p}%`
     })
+    hideRouteList()
     const simplified = simplifyPath(path3D, 1.0)
     const { totalGain, totalLoss } = elevationStats(points)
     currentPath = simplified


### PR DESCRIPTION
## Summary
- Hide route selection list after a GPX file loads
- Expose helper to show the route list again
- Bump package version to 0.1.23

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a9a3e117288329bd85ffbfe119e616