### PR TITLE
feat: display version overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,10 @@
     <div id="loader-progress" class="h-full w-0 bg-blue-500"></div>
   </div>
 </div>
+<div
+  id="version"
+  class="fixed bottom-2 left-1/2 -translate-x-1/2 text-white font-sans text-sm z-50 pointer-events-none"
+></div>
 <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.22",
+      "version": "0.1.23",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "three": "^0.168.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,10 +16,10 @@ const renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
 renderer.setSize(window.innerWidth, window.innerHeight)
 
-const versionEl = document.createElement('div')
-versionEl.textContent = `v${pkg.version}`
-versionEl.className = 'fixed bottom-2 left-1/2 -translate-x-1/2 text-white font-sans text-sm z-10 pointer-events-none'
-document.body.appendChild(versionEl)
+const versionEl = document.getElementById('version') as HTMLDivElement | null
+if (versionEl) {
+  versionEl.textContent = `v${pkg.version}`
+}
 
 // Scene & Camera
 const scene = new THREE.Scene()


### PR DESCRIPTION
## Summary
- show app version in fixed footer element
- update version to 0.1.23

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a9a4724ba48329a981fe0d76d2c65b