### PR TITLE
feat: add home button to reset route

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,12 @@
 </head>
 <body class="m-0 overflow-hidden bg-neutral-900">
 <canvas id="app" class="block"></canvas>
+<button
+  id="home-btn"
+  class="hidden fixed top-4 left-4 z-20 bg-white text-black text-xs font-sans px-2 py-1 rounded"
+>
+  Accueil
+</button>
 <div
   id="route-list"
   class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 bg-black/40 p-1 text-white text-xs font-sans"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.23",
+      "version": "0.1.24",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "flowbite": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ const N = 184 // nombre de cyclistes
 const canvas = document.getElementById('app') as HTMLCanvasElement
 const loaderEl = document.getElementById('loader') as HTMLDivElement
 const loaderProgress = document.getElementById('loader-progress') as HTMLDivElement
+const homeBtn = document.getElementById('home-btn') as HTMLButtonElement
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
 renderer.setSize(window.innerWidth, window.innerHeight)
@@ -20,6 +21,13 @@ const versionEl = document.createElement('div')
 versionEl.textContent = `v${pkg.version}`
 versionEl.className = 'fixed bottom-2 left-1/2 -translate-x-1/2 text-white font-sans text-sm z-10 pointer-events-none'
 document.body.appendChild(versionEl)
+
+homeBtn.addEventListener('click', () => {
+  stopAnimation()
+  canvas.classList.add('hidden')
+  showRouteList()
+  homeBtn.classList.add('hidden')
+})
 
 // Scene & Camera
 const scene = new THREE.Scene()
@@ -95,6 +103,7 @@ addEventListener('resize', () => {
 
 // Boucle
 function tick() {
+  if (!animating) return
   const now = performance.now()
   const dt = Math.min(0.05, (now - last) / 1000)
   last = now
@@ -103,7 +112,7 @@ function tick() {
   worker.postMessage({ type: 'step', payload: { dt } })
 
   renderer.render(scene, camera)
-  requestAnimationFrame(tick)
+  if (animating) requestAnimationFrame(tick)
 }
 
 function startAnimation() {
@@ -112,6 +121,10 @@ function startAnimation() {
     last = performance.now()
     requestAnimationFrame(tick)
   }
+}
+
+function stopAnimation() {
+  animating = false
 }
 // GPX loading and road rendering
 
@@ -210,6 +223,7 @@ document.addEventListener('DOMContentLoaded', () => {
     loaderEl.classList.remove('flex')
     loaderEl.classList.toggle('hidden', true)
     canvas.classList.toggle('hidden', false)
+    homeBtn.classList.remove('hidden')
   })
 })
 


### PR DESCRIPTION
## Summary
- add fixed "Accueil" button to return to route selection
- allow stopping animation and hiding canvas when going home
- bump version to 0.1.24

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68a9a5690a9c8329a09f60440a6d9325