### PR TITLE
fix: initialize Rapier with named import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/physics/worker.ts
+++ b/src/physics/worker.ts
@@ -1,4 +1,4 @@
-import init, * as RAPIER from '@dimforge/rapier3d-compat'
+import * as RAPIER from '@dimforge/rapier3d-compat'
 
 let world: RAPIER.World
 let N = 0
@@ -22,7 +22,7 @@ self.onmessage = async (e: MessageEvent) => {
   const { type, payload }: { type: string; payload: any } = e.data || {}
 
   if (type === 'init') {
-    if (!world) await (init as unknown as () => Promise<void>)() // charge le WASM
+    if (!world) await RAPIER.init() // charge le WASM
     // réinitialise le monde à chaque nouvelle préparation de parcours
     world = new RAPIER.World({ x: 0, y: 0, z: 0 })
 


### PR DESCRIPTION
## Summary
- fix worker initialization by calling `RAPIER.init`
- bump version to 0.1.25

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9a73989688329b022ee41f8be5819