### PR TITLE
fix: display version in footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.24",
+      "version": "0.1.25",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "flowbite": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 // src/main.ts
 import * as THREE from 'three'
-import pkg from '../package.json'
+import pkg from '../package.json' assert { type: 'json' }
 import './style.css'
 import { parseGPX, projectToLocal, type GPXPoint, type Vec3 } from './gpx'
 import { initRouteSelector } from './ui/routeSelector'
@@ -17,10 +17,6 @@ const renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
 renderer.setSize(window.innerWidth, window.innerHeight)
 
-const versionEl = document.getElementById('version') as HTMLDivElement | null
-if (versionEl) {
-  versionEl.textContent = `v${pkg.version}`
-}
 
 homeBtn.addEventListener('click', () => {
   stopAnimation()
@@ -187,6 +183,10 @@ function rebuildRoute() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  const versionEl = document.getElementById('version') as HTMLDivElement | null
+  if (versionEl) {
+    versionEl.textContent = `v${pkg.version}`
+  }
   initRouteSelector('route-list', async (_path3D, _points, url) => {
     loaderEl.classList.add('flex')
     loaderEl.classList.toggle('hidden', false)


### PR DESCRIPTION
## Summary
- ensure version text renders after DOM load and import package.json with JSON assertion
- bump package version

## Testing
- `npm test`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_b_68a9a6b863a88329a0b4a07bc1bd53fe