### PR TITLE
refactor: use Flowbite list group for route selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,10 +14,10 @@
 >
   Accueil
 </button>
-<div
-  id="route-list"
-  class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 w-full max-w-md space-y-2 rounded-lg bg-white/90 p-4 text-sm font-sans text-gray-900 shadow dark:bg-gray-800/90 dark:text-gray-200"
-></div>
+  <ul
+    id="route-list"
+    class="list-group fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 w-full max-w-md divide-y divide-gray-200 rounded-lg bg-white/90 p-4 text-sm font-sans text-gray-900 shadow dark:divide-gray-700 dark:bg-gray-800/90 dark:text-gray-200"
+  ></ul>
 <div id="loader" class="hidden fixed inset-0 z-[100] items-center justify-center bg-black/70">
   <div id="loader-bar" class="w-4/5 max-w-[400px] h-3 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
     <div id="loader-progress" class="h-full w-0 bg-blue-600"></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.32",
+  "version": "0.1.33",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/ui/routeSelector.ts
+++ b/src/ui/routeSelector.ts
@@ -10,17 +10,17 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
   const files: { name: string; url: string }[] = await res.json()
 
   if (!files.length) {
-    const empty = document.createElement('div')
+    const empty = document.createElement('li')
     empty.textContent = 'Aucun parcours trouvé'
-    empty.classList.add('text-sm', 'text-gray-500', 'dark:text-gray-400')
+    empty.classList.add('list-group-item', 'text-sm', 'text-gray-500', 'dark:text-gray-400')
     container.appendChild(empty)
     return
   }
 
   for (const file of files) {
-    const item = document.createElement('div')
+    const item = document.createElement('li')
     item.classList.add(
-      'mb-2',
+      'list-group-item',
       'p-2',
       'rounded-lg',
       'border',


### PR DESCRIPTION
## Summary
- use Flowbite list group wrapper in `index.html`
- render route options as Flowbite list-group items with dark theme styles
- bump version to 0.1.33

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9c3c4aaa08329964725e8ae1e7f83