### PR TITLE
Fix physics worker init race

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.32",
+  "version": "0.1.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.32",
+      "version": "0.1.34",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "flowbite": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -114,6 +114,7 @@ worker.onmessage = (e: MessageEvent) => {
       riders.setMatrixAt(i, tmp.matrix)
     }
     riders.instanceMatrix.needsUpdate = true
+    if (!animating) startAnimation()
   }
 }
 
@@ -362,7 +363,6 @@ document.addEventListener('DOMContentLoaded', () => {
     riders.instanceMatrix.needsUpdate = true
     focusSelected()
     cameraPrev.copy(camera.position)
-    startAnimation()
 
     console.log(`D+ ${Math.round(totalGain)} m · D- ${Math.round(totalLoss)} m`)
     loaderEl.classList.remove('flex')

--- a/src/physics/worker.ts
+++ b/src/physics/worker.ts
@@ -59,6 +59,8 @@ self.onmessage = async (e: MessageEvent) => {
   }
 
   if (type === 'step') {
+    if (!world) return // ignore steps before initialization
+
     const dt: number = payload.dt
 
     // simple logique : avance sur +X avec légère ondulation en Z


### PR DESCRIPTION
## Summary
- prevent worker steps before world initialization
- start animation after first physics state
- bump version to 0.1.34

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68a9f99319e48329bbe804c16e430acd