### PR TITLE
feat: add UI root and SEO tags

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,13 +1,25 @@
 <!doctype html>
-<html lang="fr" class="dark">
+<html lang="fr">
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<link rel="icon" href="/favicon.ico" />
-<title>Roue libre – Three + Rapier</title>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Roue libre – Three + Rapier</title>
+  <meta name="description" content="Roue libre showcase using Three.js and Rapier" />
+  <link rel="icon" href="/favicon.ico" />
+  <style>
+    body { font-family: system-ui, sans-serif; }
+  </style>
+  <script>
+    (() => {
+      if (localStorage.getItem('theme') === 'dark') {
+        document.documentElement.classList.add('dark')
+      }
+    })()
+  </script>
 </head>
 <body class="m-0 overflow-hidden bg-neutral-900">
 <canvas id="app" class="block"></canvas>
+<div id="ui-root" class="fixed inset-0 z-50 pointer-events-none"></div>
 <button
   id="home-btn"
   class="hidden fixed top-4 left-4 z-20 font-sans btn btn-sm btn-primary"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "flowbite": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- add overlay root container above canvas
- improve head with SEO meta and system font styling
- honor saved dark mode preference and bump version to 0.1.35

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aac2bec5308329a409cdc768d09278