### PR TITLE
fix: reinitialize physics buffer after transfer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/physics/worker.ts
+++ b/src/physics/worker.ts
@@ -56,6 +56,8 @@ self.onmessage = async (e: MessageEvent) => {
       { type: 'state', data: positions.buffer },
       [positions.buffer]
     )
+    // recréer un buffer côté worker (car transféré)
+    positions = new Float32Array(N * 3)
   }
 
   if (type === 'step') {


### PR DESCRIPTION
## Summary
- recreate positions buffer after initial postMessage in physics worker to avoid DataCloneError
- bump version to 0.1.36

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68aac4655cbc8329bc00cb954c0040b7