### PR TITLE
Use Flowbite classes for UI elements

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,13 +22,13 @@
 <div id="ui-root" class="fixed inset-0 z-50 pointer-events-none"></div>
 <button
   id="home-btn"
-  class="hidden fixed top-4 left-4 z-20 font-sans btn btn-sm btn-primary"
+  class="hidden fixed top-4 left-4 z-20 font-sans text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg text-sm px-4 py-2 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
 >
   Accueil
 </button>
   <ul
     id="route-list"
-    class="list-group fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 max-w-md divide-y divide-gray-200 rounded-lg bg-white/90 p-4 text-sm font-sans text-gray-900 shadow dark:divide-gray-700 dark:bg-gray-800/90 dark:text-gray-200"
+    class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 max-w-md divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white/90 text-sm font-sans text-gray-900 shadow dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800/90 dark:text-gray-200"
   ></ul>
 <div id="loader" class="hidden fixed inset-0 z-[100] items-center justify-center bg-black/70">
   <div id="loader-bar" class="w-4/5 max-w-[400px] h-3 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/ui/routeSelector.ts
+++ b/src/ui/routeSelector.ts
@@ -12,7 +12,7 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
   if (!files.length) {
     const empty = document.createElement('li')
     empty.textContent = 'Aucun parcours trouvé'
-    empty.classList.add('list-group-item', 'text-sm', 'text-gray-500', 'dark:text-gray-400')
+    empty.classList.add('p-2', 'text-sm', 'text-gray-500', 'dark:text-gray-400')
     container.appendChild(empty)
     return
   }
@@ -20,17 +20,13 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
   for (const file of files) {
     const item = document.createElement('li')
     item.classList.add(
-      'list-group-item',
-      'p-2',
-      'rounded-lg',
-      'border',
-      'border-gray-200',
+      'cursor-pointer',
+      'px-4',
+      'py-2',
       'bg-white',
       'hover:bg-gray-100',
-      'dark:border-gray-700',
       'dark:bg-gray-800',
-      'dark:hover:bg-gray-700',
-      'cursor-pointer'
+      'dark:hover:bg-gray-700'
     )
 
     const label = document.createElement('div')


### PR DESCRIPTION
## Summary
- style home navigation button with Flowbite-compliant Tailwind classes
- adjust route selector markup to use Flowbite utility classes
- bump package version to 0.1.37

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68aac4c424588329be065a3c1b95e68b