### PR TITLE
feat: implement chase camera with damping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.35",
+  "version": "0.1.38",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.35",
+      "version": "0.1.38",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "flowbite": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/camera.ts
+++ b/src/camera.ts
@@ -2,25 +2,36 @@ import * as THREE from 'three'
 
 export function updateCameraView(
   camera: THREE.PerspectiveCamera,
+  cameraPrev: THREE.Vector3,
   pivot: THREE.Vector3,
   positions: Float32Array,
   index: number,
-  orbitYaw: number,
-  orbitPitch: number,
-  orbitRadius: number,
-  cameraHeight: number
+  followDistance: number,
+  cameraHeight: number,
+  damping: number
 ): void {
   const base = index * 4
-  pivot.set(
-    positions[base],
-    positions[base + 1],
-    positions[base + 2]
+  const x = positions[base]
+  const y = positions[base + 1]
+  const z = positions[base + 2]
+  const yaw = positions[base + 3]
+
+  pivot.set(x, y, z)
+
+  const forward = new THREE.Vector3(Math.sin(yaw), 0, Math.cos(yaw))
+  const targetPos = new THREE.Vector3(
+    x - forward.x * followDistance,
+    y + cameraHeight,
+    z - forward.z * followDistance
   )
-  const cosPitch = Math.cos(orbitPitch)
-  camera.position.set(
-    pivot.x + orbitRadius * cosPitch * Math.sin(orbitYaw),
-    pivot.y + cameraHeight + orbitRadius * Math.sin(orbitPitch),
-    pivot.z + orbitRadius * cosPitch * Math.cos(orbitYaw)
+
+  cameraPrev.lerp(targetPos, damping)
+  camera.position.copy(cameraPrev)
+
+  const lookAtTarget = new THREE.Vector3(
+    x + forward.x * followDistance,
+    y + cameraHeight,
+    z + forward.z * followDistance
   )
-  camera.lookAt(pivot.x, pivot.y + cameraHeight, pivot.z)
+  camera.lookAt(lookAtTarget)
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -90,11 +90,8 @@ let animating = false
 const cameraHeight = 1.7
 const cameraPivot = new THREE.Vector3()
 const cameraPrev = new THREE.Vector3(0, 10, 26)
-let orbitYaw = 0
-let orbitPitch = 0
-const orbitRadius = 10
-let isOrbiting = false
-const lastPointer = new THREE.Vector2()
+const followDistance = 10
+const damping = 0.1
 
 const raycaster = new THREE.Raycaster()
 const mouse = new THREE.Vector2()
@@ -131,13 +128,13 @@ addEventListener('resize', () => {
 function updateCamera() {
   updateCameraView(
     camera,
+    cameraPrev,
     cameraPivot,
     positions,
     selectedIndex,
-    orbitYaw,
-    orbitPitch,
-    orbitRadius,
-    cameraHeight
+    followDistance,
+    cameraHeight,
+    damping
   )
 }
 
@@ -172,42 +169,6 @@ canvas.addEventListener('click', (e) => {
   }
 })
 
-canvas.addEventListener('dblclick', (e) => {
-  if (e.button === 1) {
-    orbitYaw = 0
-    orbitPitch = 0
-    updateCamera()
-    cameraPrev.copy(camera.position)
-  }
-})
-
-canvas.addEventListener('pointerdown', (e) => {
-  if (e.button === 1) {
-    isOrbiting = true
-    lastPointer.set(e.clientX, e.clientY)
-    canvas.setPointerCapture(e.pointerId)
-  }
-})
-
-canvas.addEventListener('pointermove', (e) => {
-  if (!isOrbiting) return
-  const dx = e.clientX - lastPointer.x
-  const dy = e.clientY - lastPointer.y
-  lastPointer.set(e.clientX, e.clientY)
-  orbitYaw -= dx * 0.005
-  orbitPitch -= dy * 0.005
-  const limit = Math.PI / 2 - 0.01
-  orbitPitch = THREE.MathUtils.clamp(orbitPitch, -limit, limit)
-  updateCamera()
-})
-
-canvas.addEventListener('pointerup', (e) => {
-  if (e.button === 1) {
-    isOrbiting = false
-    canvas.releasePointerCapture(e.pointerId)
-  }
-})
-
 document.addEventListener('keydown', (e) => {
   let delta = 0
   switch (e.key) {
@@ -231,13 +192,13 @@ document.addEventListener('keydown', (e) => {
   changeSelectedIndex(delta, N)
   updateCameraView(
     camera,
+    cameraPrev,
     cameraPivot,
     latest,
     selectedIndex,
-    orbitYaw,
-    orbitPitch,
-    orbitRadius,
-    cameraHeight
+    followDistance,
+    cameraHeight,
+    damping
   )
 })
 

--- a/test/camera.test.ts
+++ b/test/camera.test.ts
@@ -2,45 +2,49 @@ import { describe, it, expect } from 'vitest'
 import * as THREE from 'three'
 import { updateCameraView } from '../src/camera'
 
-const orbitYaw = 0
-const orbitPitch = 0
-const orbitRadius = 10
+const followDistance = 10
 const cameraHeight = 1.7
+const damping = 1
 
 describe('camera', () => {
-  it('uses new coordinates immediately when index changes', () => {
+  it('positions camera behind selected rider looking forward', () => {
     const positions = new Float32Array([
       0, 0, 0, 0,
       10, 0, 0, 0
     ])
     const camera = new THREE.PerspectiveCamera(65, 1, 0.1, 1000)
     const pivot = new THREE.Vector3()
+    const cameraPrev = new THREE.Vector3()
 
     updateCameraView(
       camera,
+      cameraPrev,
       pivot,
       positions,
       0,
-      orbitYaw,
-      orbitPitch,
-      orbitRadius,
-      cameraHeight
+      followDistance,
+      cameraHeight,
+      damping
     )
     expect(pivot.x).toBeCloseTo(0)
 
     updateCameraView(
       camera,
+      cameraPrev,
       pivot,
       positions,
       1,
-      orbitYaw,
-      orbitPitch,
-      orbitRadius,
-      cameraHeight
+      followDistance,
+      cameraHeight,
+      damping
     )
     expect(pivot.x).toBeCloseTo(10)
     expect(camera.position.x).toBeCloseTo(10)
     expect(camera.position.y).toBeCloseTo(cameraHeight)
-    expect(camera.position.z).toBeCloseTo(orbitRadius)
+    expect(camera.position.z).toBeCloseTo(-followDistance)
+    const dir = new THREE.Vector3()
+    camera.getWorldDirection(dir)
+    expect(dir.x).toBeCloseTo(0)
+    expect(dir.z).toBeCloseTo(1)
   })
 })


### PR DESCRIPTION
## Summary
- replace orbiting camera with chase camera behind selected rider
- add smoothing with damping and forward-looking orientation
- add test for new camera behavior and bump version

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aacb7253c48329a5e46224cbf9584a