### PR TITLE
Fix UI overlay visibility and rename home button

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,22 +22,22 @@
 <div id="ui-root" class="fixed inset-0 z-50 pointer-events-none"></div>
 <button
   id="home-btn"
-  class="hidden fixed top-4 left-4 z-20 font-sans text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg text-sm px-4 py-2 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
+  class="hidden fixed top-4 left-4 z-50 font-sans text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-lg text-sm px-4 py-2 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800"
 >
-  Accueil
+  Quitter
 </button>
   <ul
     id="route-list"
     class="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 max-w-md divide-y divide-gray-200 rounded-lg border border-gray-200 bg-white/90 text-sm font-sans text-gray-900 shadow dark:divide-gray-700 dark:border-gray-700 dark:bg-gray-800/90 dark:text-gray-200"
   ></ul>
-<div id="loader" class="hidden fixed inset-0 z-[100] items-center justify-center bg-black/70">
+<div id="loader" class="hidden fixed inset-0 z-[100] flex items-center justify-center bg-black/70">
   <div id="loader-bar" class="w-4/5 max-w-[400px] h-3 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
     <div id="loader-progress" class="h-full w-0 bg-blue-600"></div>
   </div>
 </div>
 <div
   id="version"
-  class="fixed bottom-2 left-1/2 -translate-x-1/2 text-white font-sans text-sm z-50 pointer-events-none"
+  class="fixed bottom-2 left-1/2 -translate-x-1/2 text-white font-sans text-sm z-50 pointer-events-none opacity-100"
 ></div>
 <script type="module" src="/src/main.ts"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.38",
+      "version": "0.1.39",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "flowbite": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- ensure UI overlays remain visible by adjusting z-index, flex layout, and opacity
- rename home button to "Quitter"
- bump version to 0.1.39

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68aacf6c34248329bf9269d16e414d58