### PR TITLE
Rotate rider boxes to face route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.39",
+      "version": "0.1.40",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "flowbite": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ for (let i = 0; i < N; i++) {
   const row = Math.floor(i / 9)
   const col = i % 9
   tmp.position.set(-20 + row * 1.2, 1, -4 + col * 1.0)
-  tmp.rotation.set(0, 0, 0)
+  tmp.rotation.set(0, -Math.PI / 2, 0)
   tmp.updateMatrix()
   riders.setMatrixAt(i, tmp.matrix)
 }
@@ -108,7 +108,7 @@ worker.onmessage = (e: MessageEvent) => {
       const z = positions[base + 2]
       const yaw = positions[base + 3]
       tmp.position.set(x, y, z)
-      tmp.rotation.set(0, yaw, 0)
+      tmp.rotation.set(0, yaw - Math.PI / 2, 0)
       tmp.updateMatrix()
       riders.setMatrixAt(i, tmp.matrix)
     }


### PR DESCRIPTION
## Summary
- rotate instanced rider boxes 90° around Y-axis so they face the road
- update package version to 0.1.40

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68aad27a1fa48329b97cf4afde76cd1b