### PR TITLE
feat: smooth road geometry with Catmull-Rom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-    "version": "0.1.43",
+    "version": "0.1.44",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "flowbite": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.43",
+  "version": "0.1.44",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import 'flowbite'
 import { parseGPX, projectToLocal, type GPXPoint, type Vec3 } from './gpx'
 import { initRouteSelector } from './ui/routeSelector'
 import { initPeloton } from './peloton'
+import { resamplePath } from './systems/pathSmoothing'
 import { selectedIndex, setSelectedIndex, changeSelectedIndex } from './selection'
 import { StabilizedFollowCamera } from './camera/StabilizedFollowCamera'
 
@@ -319,12 +320,13 @@ document.addEventListener('DOMContentLoaded', () => {
     })
     hideRouteList()
     const simplified = simplifyPath(path3D, 1.0)
+    const smoothed = resamplePath(simplified, 1.0)
     const { totalGain, totalLoss } = elevationStats(points)
-    currentPath = simplified
+    currentPath = smoothed
     rebuildRoute()
 
     // initialise le peloton sur la route sélectionnée
-    const pelotonPos = initPeloton(simplified, N)
+    const pelotonPos = initPeloton(smoothed, N)
     positions = new Float32Array(N * 4)
     for (let i = 0; i < N; i++) {
       positions[i * 4 + 0] = pelotonPos[i * 3 + 0]

--- a/src/systems/pathSmoothing.ts
+++ b/src/systems/pathSmoothing.ts
@@ -77,3 +77,15 @@ export function createSplineHelper(spline: PathSpline, segments = 100): LineSegm
   const mat = new LineBasicMaterial({ color: 0xff0000 })
   return new LineSegments(geom, mat)
 }
+
+export function resamplePath(waypoints: Vector3[], step: number): Vector3[] {
+  const spline = new PathSpline(waypoints)
+  const resampled: Vector3[] = []
+  for (let d = 0; d <= spline.totalLength; d += step) {
+    resampled.push(spline.sampleByDistance(d).position)
+  }
+  const last = resampled[resampled.length - 1]
+  const end = waypoints[waypoints.length - 1]
+  if (!last.equals(end)) resampled.push(end.clone())
+  return resampled
+}

--- a/test/resamplePath.test.ts
+++ b/test/resamplePath.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import * as THREE from 'three'
+import { resamplePath } from '../src/systems/pathSmoothing'
+
+describe('resamplePath', () => {
+  it('adds intermediate points', () => {
+    const pts = [
+      new THREE.Vector3(0, 0, 0),
+      new THREE.Vector3(5, 0, 0),
+      new THREE.Vector3(10, 0, 5)
+    ]
+    const res = resamplePath(pts, 1)
+    expect(res.length).toBeGreaterThan(pts.length)
+    expect(res[0].distanceTo(pts[0])).toBeLessThan(1e-6)
+    expect(res[res.length - 1].distanceTo(pts[pts.length - 1])).toBeLessThan(1e-6)
+  })
+})


### PR DESCRIPTION
## Summary
- add `resamplePath` to generate Catmull-Rom spline points for smoother roads
- integrate resampled path into main scene setup and peloton initialization
- cover spline resampling with new unit test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab17aad898832998bc40feb952ac38