### PR TITLE
fix: annotate mouse events for button access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -47,7 +47,7 @@ let yawOffset = 0
 let pitchOffset = 0
 let lastMiddleTime = 0
 
-canvas.addEventListener('mousedown', (e) => {
+canvas.addEventListener('mousedown', (e: MouseEvent) => {
   if (e.button === 1) {
     e.preventDefault()
     rotating = true
@@ -56,7 +56,7 @@ canvas.addEventListener('mousedown', (e) => {
   }
 })
 
-addEventListener('mouseup', (e) => {
+addEventListener('mouseup', (e: MouseEvent) => {
   if (e.button === 1) {
     const now = performance.now()
     if (now - lastMiddleTime < 300) {
@@ -69,7 +69,7 @@ addEventListener('mouseup', (e) => {
   }
 })
 
-canvas.addEventListener('mousemove', (e) => {
+canvas.addEventListener('mousemove', (e: MouseEvent) => {
   if (rotating) {
     const dx = e.clientX - lastX
     const dy = e.clientY - lastY
@@ -86,7 +86,7 @@ const minFov = 20
 const maxFov = 100
 canvas.addEventListener(
   'wheel',
-  (e) => {
+  (e: WheelEvent) => {
     e.preventDefault()
     camera.fov = THREE.MathUtils.clamp(camera.fov + e.deltaY * 0.05, minFov, maxFov)
     camera.updateProjectionMatrix()


### PR DESCRIPTION
## Summary
- annotate mouse event listeners with explicit types to access `button`
- bump version to 0.1.47

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_b_68ab211f2ae08329bbfd64b7c111ce86