### PR TITLE
Limit middle-click camera rotation to horizontal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,9 +42,7 @@ const followCam = new StabilizedFollowCamera(camera)
 // Camera rotation with middle mouse
 let rotating = false
 let lastX = 0
-let lastY = 0
 let yawOffset = 0
-let pitchOffset = 0
 let lastMiddleTime = 0
 
 canvas.addEventListener('mousedown', (e) => {
@@ -52,7 +50,6 @@ canvas.addEventListener('mousedown', (e) => {
     e.preventDefault()
     rotating = true
     lastX = e.clientX
-    lastY = e.clientY
   }
 })
 
@@ -61,7 +58,6 @@ addEventListener('mouseup', (e) => {
     const now = performance.now()
     if (now - lastMiddleTime < 300) {
       yawOffset = 0
-      pitchOffset = 0
       focusSelected()
     }
     lastMiddleTime = now
@@ -72,12 +68,8 @@ addEventListener('mouseup', (e) => {
 canvas.addEventListener('mousemove', (e) => {
   if (rotating) {
     const dx = e.clientX - lastX
-    const dy = e.clientY - lastY
-    yawOffset += dx * 0.005
-    pitchOffset += dy * 0.005
-    pitchOffset = THREE.MathUtils.clamp(pitchOffset, -Math.PI / 3, Math.PI / 3)
+    yawOffset += dx * 0.002
     lastX = e.clientX
-    lastY = e.clientY
   }
 })
 
@@ -220,7 +212,7 @@ addEventListener('resize', () => {
 function updateCamera(dt: number) {
   followCam.update(dt, [riderObjs[selectedIndex]])
   const offsetQuat = new THREE.Quaternion().setFromEuler(
-    new THREE.Euler(pitchOffset, yawOffset, 0, 'YXZ')
+    new THREE.Euler(0, yawOffset, 0, 'YXZ')
   )
   camera.quaternion.multiply(offsetQuat)
   ;(followCam as unknown as { _smoothedQuat: THREE.Quaternion })._smoothedQuat.copy(


### PR DESCRIPTION
## Summary
- Restrict middle-click camera rotation to horizontal axis and lower sensitivity
- Bump version to 0.1.47

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab217fc0888329a512c39396e21476