### PR TITLE
fix: show route list by default

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 </button>
   <ul
     id="route-list"
-    class="hidden menu bg-base-100 rounded-box text-sm font-sans shadow fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 max-w-md"
+    class="menu bg-base-100 rounded-box text-sm font-sans shadow fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 max-w-md"
   ></ul>
 <div id="loader" class="hidden fixed inset-0 z-[100] flex items-center justify-center bg-black/70">
   <div id="loader-bar" class="w-4/5 max-w-[400px] h-3 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.46",
+      "version": "0.1.47",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- make route list visible on initial page load
- bump package version to 0.1.47

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68ab21b32d948329ba91ab34ed0576db