### PR TITLE
fix: remove inertia from camera rotation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.47",
+      "version": "0.1.48",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.47",
+  "version": "0.1.48",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,8 +40,8 @@ const followCam = new StabilizedFollowCamera(camera)
 
 
 // Camera rotation with middle mouse
+const ROT_SENSITIVITY = 0.005
 let rotating = false
-let lastX = 0
 let yawOffset = 0
 let lastMiddleTime = 0
 
@@ -49,7 +49,6 @@ canvas.addEventListener('mousedown', (e: MouseEvent) => {
   if (e.button === 1) {
     e.preventDefault()
     rotating = true
-    lastX = e.clientX
   }
 })
 
@@ -67,9 +66,7 @@ addEventListener('mouseup', (e: MouseEvent) => {
 
 canvas.addEventListener('mousemove', (e: MouseEvent) => {
   if (rotating) {
-    const dx = e.clientX - lastX
-    yawOffset += dx * 0.002
-    lastX = e.clientX
+    yawOffset += e.movementX * ROT_SENSITIVITY
   }
 })
 
@@ -210,7 +207,9 @@ addEventListener('resize', () => {
 
 // Boucle
 function updateCamera(dt: number) {
+  const prevQuat = camera.quaternion.clone()
   followCam.update(dt, [riderObjs[selectedIndex]])
+  if (rotating) camera.quaternion.copy(prevQuat)
   const offsetQuat = new THREE.Quaternion().setFromEuler(
     new THREE.Euler(0, yawOffset, 0, 'YXZ')
   )


### PR DESCRIPTION
## Summary
- remove rotational inertia by using raw mouse delta for middle-click camera rotation
- freeze follow camera orientation during manual rotation
- bump version to 0.1.48

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ac15e71c948329b4037740059d44de