### PR TITLE
fix: stop camera rotation on middle mouse release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -60,8 +60,12 @@ addEventListener('mouseup', (e: MouseEvent) => {
       focusSelected()
     }
     lastMiddleTime = now
-    rotating = false
   }
+  rotating = false
+})
+
+canvas.addEventListener('mouseleave', () => {
+  rotating = false
 })
 
 canvas.addEventListener('mousemove', (e: MouseEvent) => {


### PR DESCRIPTION
## Summary
- halt camera rotation on any mouseup and when cursor leaves the canvas
- bump version to 0.1.49

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aec046447c83298fc770d618c50332