### PR TITLE
Fix version overlay not appearing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -344,12 +344,11 @@ function rebuildRoute() {
   scene.add(markings)
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-  const versionEl = document.getElementById('version') as HTMLDivElement | null
-  if (versionEl) {
-    versionEl.textContent = `v${pkg.version}`
-  }
-  initRouteSelector('route-list', async (_path3D, _points, url) => {
+const versionEl = document.getElementById('version') as HTMLDivElement | null
+if (versionEl) {
+  versionEl.textContent = `v${pkg.version}`
+}
+initRouteSelector('route-list', async (_path3D, _points, url) => {
     loaderEl.classList.add('flex')
     loaderEl.classList.toggle('hidden', false)
     loaderProgress.style.width = '0%'
@@ -409,7 +408,7 @@ document.addEventListener('DOMContentLoaded', () => {
     canvas.classList.toggle('hidden', false)
     homeBtn.classList.remove('hidden')
   })
-})
+
 
 function elevationStats(pts: GPXPoint[]): { totalGain: number; totalLoss: number } {
   let totalGain = 0


### PR DESCRIPTION
## Summary
- set app version immediately instead of on `DOMContentLoaded`
- bump version to 0.1.49

## Testing
- `npm run lint`
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aec1bb314c8329a2b228d373b08bf0