### PR TITLE
Add simulation start/pause/reset controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,32 @@
   </div>
 </div>
 <div
+  id="controls"
+  class="fixed bottom-4 right-4 z-50 flex gap-2 pointer-events-auto"
+>
+  <button
+    id="start-btn"
+    class="btn btn-primary font-sans"
+    disabled
+  >
+    Start
+  </button>
+  <button
+    id="pause-btn"
+    class="btn btn-primary font-sans"
+    disabled
+  >
+    Pause
+  </button>
+  <button
+    id="reset-btn"
+    class="btn btn-primary font-sans"
+    disabled
+  >
+    Reset
+  </button>
+</div>
+<div
   id="version"
   class="fixed bottom-2 left-1/2 -translate-x-1/2 text-white font-sans text-sm z-50 pointer-events-none opacity-100"
 ></div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,11 @@ const canvas = document.getElementById('app') as HTMLCanvasElement
 const loaderEl = document.getElementById('loader') as HTMLDivElement
 const loaderProgress = document.getElementById('loader-progress') as HTMLDivElement
 const homeBtn = document.getElementById('home-btn') as HTMLButtonElement
+const startBtn = document.getElementById('start-btn') as HTMLButtonElement
+const pauseBtn = document.getElementById('pause-btn') as HTMLButtonElement
+const resetBtn = document.getElementById('reset-btn') as HTMLButtonElement
+let currentPath: Vec3[] | null = null
+let pathData: Float32Array | null = null
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true })
 renderer.setPixelRatio(Math.min(devicePixelRatio, 2))
 renderer.setSize(window.innerWidth, window.innerHeight)
@@ -26,6 +31,59 @@ homeBtn.addEventListener('click', () => {
   canvas.classList.add('hidden')
   showRouteList()
   homeBtn.classList.add('hidden')
+  startBtn.disabled = true
+  pauseBtn.disabled = true
+  resetBtn.disabled = true
+})
+
+startBtn.addEventListener('click', () => {
+  startAnimation()
+  startBtn.disabled = true
+  startBtn.textContent = 'Start'
+  pauseBtn.disabled = false
+})
+
+pauseBtn.addEventListener('click', () => {
+  stopAnimation()
+  startBtn.disabled = false
+  startBtn.textContent = 'Reprendre'
+  pauseBtn.disabled = true
+})
+
+resetBtn.addEventListener('click', () => {
+  stopAnimation()
+  if (currentPath && pathData) {
+    const pelotonPos = initPeloton(currentPath, N)
+    positions = new Float32Array(N * 4)
+    for (let i = 0; i < N; i++) {
+      positions[i * 4 + 0] = pelotonPos[i * 3 + 0]
+      positions[i * 4 + 1] = pelotonPos[i * 3 + 1]
+      positions[i * 4 + 2] = pelotonPos[i * 3 + 2]
+      positions[i * 4 + 3] = 0
+    }
+    const pathCopy = pathData.slice()
+    worker.postMessage(
+      { type: 'init', payload: { N, positions: pelotonPos.buffer, path: pathCopy.buffer } },
+      [pelotonPos.buffer, pathCopy.buffer]
+    )
+    for (let i = 0; i < N; i++) {
+      const base = i * 4
+      const x = positions[base + 0]
+      const y = positions[base + 1]
+      const z = positions[base + 2]
+      tmp.position.set(x, y, z)
+      tmp.rotation.set(0, 0, 0)
+      tmp.updateMatrix()
+      riders.setMatrixAt(i, tmp.matrix)
+      riderObjs[i].position.copy(tmp.position)
+    }
+    riders.instanceMatrix.needsUpdate = true
+    focusSelected()
+    renderer.render(scene, camera)
+  }
+  startBtn.disabled = false
+  startBtn.textContent = 'Start'
+  pauseBtn.disabled = true
 })
 
 // Scene & Camera
@@ -194,7 +252,6 @@ worker.onmessage = (e: MessageEvent) => {
       riderObjs[i].position.set(x, y, z)
     }
     riders.instanceMatrix.needsUpdate = true
-    if (!animating) startAnimation()
   }
 }
 
@@ -291,7 +348,6 @@ const DASH_LENGTH = 2
 const GAP_LENGTH = 10
 const LINE_WIDTH = 0.15
 
-let currentPath: Vec3[] | null = null
 
 async function loadGPX(url: string, onProgress: (p: number) => void): Promise<{ path3D: Vec3[]; points: GPXPoint[] }> {
   const res = await fetch(url)
@@ -385,6 +441,7 @@ document.addEventListener('DOMContentLoaded', () => {
       pathArray[i * 3 + 2] = p.z
     }
 
+    pathData = pathArray.slice()
     worker.postMessage(
       { type: 'init', payload: { N, positions: pelotonPos.buffer, path: pathArray.buffer } },
       [pelotonPos.buffer, pathArray.buffer]
@@ -402,12 +459,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     riders.instanceMatrix.needsUpdate = true
     focusSelected()
+    renderer.render(scene, camera)
 
     console.log(`D+ ${Math.round(totalGain)} m · D- ${Math.round(totalLoss)} m`)
     loaderEl.classList.remove('flex')
     loaderEl.classList.toggle('hidden', true)
     canvas.classList.toggle('hidden', false)
     homeBtn.classList.remove('hidden')
+    startBtn.disabled = false
+    startBtn.textContent = 'Start'
+    pauseBtn.disabled = true
+    resetBtn.disabled = false
   })
 })
 

--- a/src/peloton.ts
+++ b/src/peloton.ts
@@ -1,13 +1,10 @@
 import type { Vec3 } from './gpx'
 
-export let simulationStarted = false
-
 /**
  * Initialise les positions des cyclistes sur le début du parcours sélectionné
  * en formant un peloton de 9 de front.
  */
 export function initPeloton(path: Vec3[], N: number): Float32Array {
-  simulationStarted = true
   const positions = new Float32Array(N * 3)
   if (path.length < 2) return positions
 

--- a/test/relayCluster.test.js
+++ b/test/relayCluster.test.js
@@ -1,17 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { initPeloton, simulationStarted } from '../src/peloton';
+import { initPeloton } from '../src/peloton';
 
 describe('relayCluster', () => {
   it('placeholder', () => {
     expect(true).toBe(true);
   });
 
-  it('starts simulation after route preparation', () => {
+  it('initialises peloton positions', () => {
     const path = [
       { x: 0, y: 0, z: 0 },
       { x: 10, y: 0, z: 0 }
     ];
-    initPeloton(path, 5);
-    expect(simulationStarted).toBe(true);
+    const pos = initPeloton(path, 5);
+    expect(pos).toBeInstanceOf(Float32Array);
+    expect(pos.length).toBe(15);
   });
 });


### PR DESCRIPTION
## Summary
- add bottom-right Start, Pause, and Reset buttons to control the race simulation
- prevent auto-start and allow resetting riders to their initial positions
- bump version to 0.1.49

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aec1ca2f78832985bbef42795a00ed