### PR TITLE
fix: ensure UI controls and version label visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.49",
+  "version": "0.1.50",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/style.css
+++ b/src/style.css
@@ -4,3 +4,35 @@
 body {
   margin: 0;
 }
+
+/* Ensure UI elements remain visible even without Tailwind utilities */
+#controls {
+  position: fixed;
+  bottom: 1rem; /* bottom-4 */
+  right: 1rem; /* right-4 */
+  z-index: 50; /* z-50 */
+  display: flex; /* flex */
+  gap: 0.5rem; /* gap-2 */
+  pointer-events: auto; /* pointer-events-auto */
+}
+
+#version {
+  position: fixed;
+  bottom: 0.5rem; /* bottom-2 */
+  left: 50%; /* left-1/2 */
+  transform: translateX(-50%); /* -translate-x-1/2 */
+  z-index: 50; /* z-50 */
+  pointer-events: none; /* pointer-events-none */
+  color: #fff; /* text-white */
+  font-family: system-ui, sans-serif; /* font-sans */
+  font-size: 0.875rem; /* text-sm */
+  opacity: 1; /* opacity-100 */
+}
+
+#home-btn {
+  position: fixed;
+  top: 1rem; /* top-4 */
+  left: 1rem; /* left-4 */
+  z-index: 50; /* z-50 */
+  font-family: system-ui, sans-serif; /* font-sans */
+}


### PR DESCRIPTION
## Summary
- add fallback CSS positioning for control buttons and version indicator
- bump package version to 0.1.50

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0113ede7c83299ce8d6c9f0a78c2e