### PR TITLE
chore: streamline Tailwind setup with daisyUI plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.50",
+  "version": "0.1.51",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,5 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+@plugin "daisyui";
 body {
   margin: 0;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,4 @@ export default {
   theme: {
     extend: {},
   },
-  plugins: [
-    require('daisyui')
-  ],
 }


### PR DESCRIPTION
## Summary
- replace legacy Tailwind directives with `@import` and daisyUI plugin
- drop explicit daisyUI plugin config
- bump version to 0.1.51

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68b6d66fef388329b22c3defb172ed4b