### PR TITLE
feat: set light theme default

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="fr">
+<html lang="fr" data-theme="light">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- default the HTML `data-theme` to light
- bump version to 0.1.52

## Testing
- `npm run lint`
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b6d79d3ba083298d971fa697f3e3cc