### PR TITLE
feat: add DaisyUI demo component and UI test page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,7 @@ worker.postMessage({
 })
 ```
 
+
+## Test de l'interface
+
+Une page est disponible pour tester les composants DaisyUI : [http://localhost:5173/ui-test](http://localhost:5173/ui-test).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.50",
+  "version": "0.1.53",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.50",
+      "version": "0.1.53",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.52",
+  "version": "0.1.53",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/DaisyUiDemo.ts
+++ b/src/components/DaisyUiDemo.ts
@@ -1,0 +1,21 @@
+/**
+ * Simple demonstration of DaisyUI components.
+ */
+export function createDaisyUiDemo(): HTMLElement {
+  const container = document.createElement('div')
+  container.innerHTML = `
+    <button class="btn btn-primary">Primary</button>
+    <button class="btn">Default</button>
+    <input class="input input-bordered" placeholder="Your name" />
+    <select class="select select-bordered"><option>One</option><option>Two</option></select>
+    <span class="badge badge-info">Info</span>
+  `
+  return container
+}
+
+/**
+ * Mount the demo inside the provided element.
+ */
+export function mountDaisyUiDemo(parent: HTMLElement): void {
+  parent.appendChild(createDaisyUiDemo())
+}

--- a/ui-test.html
+++ b/ui-test.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="fr" data-theme="light">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UI Test</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module">
+    import { mountDaisyUiDemo } from '/src/components/DaisyUiDemo.ts'
+    const app = document.getElementById('app')
+    if (app) mountDaisyUiDemo(app)
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add DaisyUI demo component
- expose it through new `/ui-test` page for manual testing
- document the new route and bump package version

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b6d873f9708329b88aa1db5bb93b94