### PR TITLE
fix: barre de progression visible dans le loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
   ></ul>
 <div id="loader" class="hidden fixed inset-0 z-[100] flex items-center justify-center bg-black/70">
   <div id="loader-bar" class="w-4/5 max-w-[400px] h-3 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
-    <div id="loader-progress" class="h-full w-0 bg-blue-600"></div>
+    <div id="loader-progress" class="h-full bg-blue-600"></div>
   </div>
 </div>
 <div

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- remove Tailwind width class from loader progress bar so JS updates are visible
- bump version to 0.1.54

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68b98a6474e08329b7134e893e668f33