### PR TITLE
feat: highlight route preview canvas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.53",
+    "version": "0.1.54",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/ui/routeSelector.ts
+++ b/src/ui/routeSelector.ts
@@ -48,6 +48,7 @@ export async function initRouteSelector(containerId: string, onSelect: RouteSele
           const canvas = document.createElement('canvas')
           canvas.width = 120
           canvas.height = 40
+          canvas.className = 'rounded bg-base-300'
           btn.appendChild(canvas)
 
           const ctx = canvas.getContext('2d')


### PR DESCRIPTION
## Summary
- add background to route preview canvas so it stands out
- bump version to 0.1.54

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b98a2f1ebc8329bfe4bf77109d1aec