### PR TITLE
feat: align peloton with course start

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-      "version": "0.1.53",
+      "version": "0.1.54",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.53",
+  "version": "0.1.54",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -54,12 +54,16 @@ resetBtn.addEventListener('click', () => {
   stopAnimation()
   if (currentPath && pathData) {
     const pelotonPos = initPeloton(currentPath, N)
+    const yaw0 = Math.atan2(
+      currentPath[1].x - currentPath[0].x,
+      currentPath[1].z - currentPath[0].z
+    )
     positions = new Float32Array(N * 4)
     for (let i = 0; i < N; i++) {
       positions[i * 4 + 0] = pelotonPos[i * 3 + 0]
       positions[i * 4 + 1] = pelotonPos[i * 3 + 1]
       positions[i * 4 + 2] = pelotonPos[i * 3 + 2]
-      positions[i * 4 + 3] = 0
+      positions[i * 4 + 3] = yaw0
     }
     const pathCopy = pathData.slice()
     worker.postMessage(
@@ -72,7 +76,7 @@ resetBtn.addEventListener('click', () => {
       const y = positions[base + 1]
       const z = positions[base + 2]
       tmp.position.set(x, y, z)
-      tmp.rotation.set(0, 0, 0)
+      tmp.rotation.set(0, yaw0 - Math.PI / 2, 0)
       tmp.updateMatrix()
       riders.setMatrixAt(i, tmp.matrix)
       riderObjs[i].position.copy(tmp.position)
@@ -305,6 +309,8 @@ const ROAD_WIDTH = 8
 const DASH_LENGTH = 2
 const GAP_LENGTH = 10
 const LINE_WIDTH = 0.15
+const START_LINE_OFFSET = 1
+const START_LINE_WIDTH = 0.3
 
 
 async function loadGPX(url: string, onProgress: (p: number) => void): Promise<{ path3D: Vec3[]; points: GPXPoint[] }> {
@@ -350,12 +356,16 @@ function rebuildRoute() {
   if (!currentPath) return
   removeIfPresent('routeMesh')
   removeIfPresent('centerMarkings')
+  removeIfPresent('startLine')
   const road = buildRoadMesh(currentPath, ROAD_WIDTH)
   road.name = 'routeMesh'
   scene.add(road)
   const markings = buildCenterDashes(currentPath, LINE_WIDTH, DASH_LENGTH, GAP_LENGTH)
   markings.name = 'centerMarkings'
   scene.add(markings)
+  const start = buildStartLine(currentPath, ROAD_WIDTH, START_LINE_OFFSET)
+  start.name = 'startLine'
+  scene.add(start)
 }
 
 const versionEl = document.getElementById('version') as HTMLDivElement | null
@@ -379,12 +389,13 @@ initRouteSelector('route-list', async (_path3D, _points, url) => {
 
     // initialise le peloton sur la route sélectionnée
     const pelotonPos = initPeloton(smoothed, N)
+    const yaw0 = Math.atan2(smoothed[1].x - smoothed[0].x, smoothed[1].z - smoothed[0].z)
     positions = new Float32Array(N * 4)
     for (let i = 0; i < N; i++) {
       positions[i * 4 + 0] = pelotonPos[i * 3 + 0]
       positions[i * 4 + 1] = pelotonPos[i * 3 + 1]
       positions[i * 4 + 2] = pelotonPos[i * 3 + 2]
-      positions[i * 4 + 3] = 0
+      positions[i * 4 + 3] = yaw0
     }
 
     const median = Math.floor(N / 2)
@@ -409,7 +420,7 @@ initRouteSelector('route-list', async (_path3D, _points, url) => {
       const y = positions[base + 1]
       const z = positions[base + 2]
       tmp.position.set(x, y, z)
-      tmp.rotation.set(0, 0, 0)
+      tmp.rotation.set(0, yaw0 - Math.PI / 2, 0)
       tmp.updateMatrix()
       riders.setMatrixAt(i, tmp.matrix)
       riderObjs[i].position.copy(tmp.position)
@@ -542,6 +553,20 @@ function buildCenterDashes(centerLine: Vec3[], lineWidth: number, dashLen: numbe
   geom.computeVertexNormals()
   const mat = new THREE.MeshStandardMaterial({ color: 0xffffff })
   return new THREE.Mesh(geom, mat)
+}
+
+function buildStartLine(centerLine: Vec3[], width: number, offset: number): THREE.Mesh {
+  if (centerLine.length < 2) return new THREE.Mesh()
+  const a = centerLine[0]
+  const b = centerLine[1]
+  const dir = new THREE.Vector3(b.x - a.x, 0, b.z - a.z).normalize()
+  const center = new THREE.Vector3(a.x, a.y + 0.02, a.z).add(dir.clone().multiplyScalar(offset))
+  const geom = new THREE.BoxGeometry(width, 0.02, START_LINE_WIDTH)
+  const mat = new THREE.MeshStandardMaterial({ color: 0xffffff })
+  const mesh = new THREE.Mesh(geom, mat)
+  mesh.position.copy(center)
+  mesh.rotation.y = Math.atan2(dir.x, dir.z)
+  return mesh
 }
 
 function removeIfPresent(name: string): void {

--- a/src/peloton.ts
+++ b/src/peloton.ts
@@ -22,8 +22,9 @@ export function initPeloton(path: Vec3[], N: number): Float32Array {
   for (let i = 0; i < N; i++) {
     const row = Math.floor(i / 9)
     const col = i % 9 - 4 // centré
-    const x = p0.x + nx * row * 1.2 + rx * col * 1.0
-    const z = p0.z + nz * row * 1.2 + rz * col * 1.0
+    // les rangées sont placées en arrière de la ligne de départ
+    const x = p0.x - nx * row * 1.2 + rx * col * 1.0
+    const z = p0.z - nz * row * 1.2 + rz * col * 1.0
     positions[i * 3 + 0] = x
     positions[i * 3 + 1] = p0.y + 1
     positions[i * 3 + 2] = z

--- a/test/initialization.test.ts
+++ b/test/initialization.test.ts
@@ -35,5 +35,16 @@ describe('initialization', () => {
     expect(camera.position.z).toBeCloseTo(z)
     expect(cameraPrev.equals(camera.position)).toBe(true)
   })
+
+  it('places subsequent rows behind the start line', () => {
+    const path = [
+      { x: 0, y: 0, z: 0 },
+      { x: 10, y: 0, z: 0 }
+    ]
+    const positions = initPeloton(path, N)
+    const firstRowX = positions[0]
+    const secondRowX = positions[9 * 3 + 0]
+    expect(secondRowX).toBeLessThan(firstRowX)
+  })
 })
 


### PR DESCRIPTION
## Summary
- place peloton rows behind the start line along the route
- draw a start line mesh and orient riders along the course
- verify starting grid placement with new test

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68b98b7f69b48329a9c71405b5957e8d