### PR TITLE
fix: restore dark theme after quitting

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,9 @@
   </style>
   <script>
     (() => {
-      if (localStorage.getItem('theme') === 'dark') {
-        document.documentElement.classList.add('dark')
-      }
+      const theme = localStorage.getItem('theme') === 'dark' ? 'dark' : 'light'
+      document.documentElement.setAttribute('data-theme', theme)
+      document.documentElement.classList.toggle('dark', theme === 'dark')
     })()
   </script>
 </head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- ensure stored theme sets `data-theme` and dark class
- bump package version to 0.1.55

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b98cf85ee08329b5dabc124026f392