### PR TITLE
feat: color loader progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,12 @@
     class="menu bg-base-100 rounded-box text-sm font-sans shadow fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-10 max-w-md"
   ></ul>
 <div id="loader" class="hidden fixed inset-0 z-[100] flex items-center justify-center bg-black/70">
-  <div id="loader-bar" class="w-4/5 max-w-[400px] h-3 rounded-full bg-gray-200 dark:bg-gray-700 overflow-hidden">
-    <div id="loader-progress" class="h-full bg-blue-600"></div>
-  </div>
+  <progress
+    id="loader-progress"
+    class="progress progress-primary w-4/5 max-w-[400px]"
+    value="0"
+    max="100"
+  ></progress>
 </div>
 <div
   id="controls"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.54",
+  "version": "0.1.55",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,7 +14,7 @@ const N = 184 // nombre de cyclistes
 // Renderer
 const canvas = document.getElementById('app') as HTMLCanvasElement
 const loaderEl = document.getElementById('loader') as HTMLDivElement
-const loaderProgress = document.getElementById('loader-progress') as HTMLDivElement
+const loaderProgress = document.getElementById('loader-progress') as HTMLProgressElement
 const homeBtn = document.getElementById('home-btn') as HTMLButtonElement
 const startBtn = document.getElementById('start-btn') as HTMLButtonElement
 const pauseBtn = document.getElementById('pause-btn') as HTMLButtonElement
@@ -365,10 +365,10 @@ if (versionEl) {
 initRouteSelector('route-list', async (_path3D, _points, url) => {
     loaderEl.classList.add('flex')
     loaderEl.classList.toggle('hidden', false)
-    loaderProgress.style.width = '0%'
+    loaderProgress.value = 0
     canvas.classList.toggle('hidden', true)
     const { path3D, points } = await loadGPX(url, (p) => {
-      loaderProgress.style.width = `${p}%`
+      loaderProgress.value = p
     })
     hideRouteList()
     const simplified = simplifyPath(path3D, 1.0)


### PR DESCRIPTION
## Summary
- replace loader bar with a DaisyUI progress element using primary color
- adjust loader logic to update progress value
- bump version to 0.1.55

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b98ce3285c8329b18c2adebbbbe5d0