### PR TITLE
feat: improve peloton distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.56",
+  "version": "0.1.57",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/physics/worker.ts
+++ b/src/physics/worker.ts
@@ -45,6 +45,7 @@ self.onmessage = async (e: MessageEvent) => {
 
     N = payload.N as number
     const initial = new Float32Array(payload.positions)
+    const yawOffsets = new Float32Array(payload.yaw)
     const raw = new Float32Array(payload.path)
     const waypoints: Vector3[] = []
     for (let i = 0; i < raw.length; i += 3) {
@@ -86,7 +87,7 @@ self.onmessage = async (e: MessageEvent) => {
 
       const pos = center.clone().add(right.multiplyScalar(offset))
       rb.setTranslation({ x: pos.x, y: pos.y + 1, z: pos.z }, true)
-      const yaw = Math.atan2(tangent.x, tangent.z)
+      const yaw = Math.atan2(tangent.x, tangent.z) + yawOffsets[i]
       state[i * 4 + 0] = pos.x
       state[i * 4 + 1] = pos.y + 1
       state[i * 4 + 2] = pos.z

--- a/test/initialization.test.ts
+++ b/test/initialization.test.ts
@@ -36,15 +36,16 @@ describe('initialization', () => {
     expect(cameraPrev.equals(camera.position)).toBe(true)
   })
 
-  it('places subsequent rows behind the start line', () => {
+  it('keeps all riders at or behind the start line', () => {
     const path = [
       { x: 0, y: 0, z: 0 },
       { x: 10, y: 0, z: 0 }
     ]
     const positions = initPeloton(path, N)
-    const firstRowX = positions[0]
-    const secondRowX = positions[9 * 3 + 0]
-    expect(secondRowX).toBeLessThan(firstRowX)
+    for (let i = 0; i < N; i++) {
+      const x = positions[i * 3 + 0]
+      expect(x).toBeLessThanOrEqual(path[0].x)
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- Generate peloton positions in (s,t) space with clamped jitter and Poisson-disk spacing
- Add small random yaw offsets per rider and forward to physics worker
- Ensure all riders start behind the line and update tests

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_b_68bb126e96b08329a5124bca6bee420e