### PR TITLE
feat: chase camera follows median runner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rouelibre",
-  "version": "0.1.56",
+  "version": "0.1.58",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-    "version": "0.1.56",
+    "version": "0.1.58",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.57",
+  "version": "0.1.58",
   "private": true,
   "type": "module",
   "scripts": {

--- a/test/camera.test.ts
+++ b/test/camera.test.ts
@@ -4,47 +4,39 @@ import { updateCameraView } from '../src/camera'
 
 const followDistance = 10
 const cameraHeight = 1.7
-const damping = 1
+const damping = 8
+const lookAhead = 15
+const dt = 1
 
 describe('camera', () => {
-  it('positions camera behind selected rider looking forward', () => {
+  it('chases the median rider aligned with the road', () => {
     const positions = new Float32Array([
       0, 0, 0, 0,
       10, 0, 0, 0
     ])
     const camera = new THREE.PerspectiveCamera(65, 1, 0.1, 1000)
     const pivot = new THREE.Vector3()
-    const cameraPrev = new THREE.Vector3()
+    const cameraVel = new THREE.Vector3()
 
     updateCameraView(
       camera,
-      cameraPrev,
+      cameraVel,
       pivot,
       positions,
-      0,
       followDistance,
       cameraHeight,
-      damping
-    )
-    expect(pivot.x).toBeCloseTo(0)
-
-    updateCameraView(
-      camera,
-      cameraPrev,
-      pivot,
-      positions,
-      1,
-      followDistance,
-      cameraHeight,
-      damping
+      damping,
+      lookAhead,
+      dt
     )
     expect(pivot.x).toBeCloseTo(10)
-    expect(camera.position.x).toBeCloseTo(10)
-    expect(camera.position.y).toBeCloseTo(cameraHeight)
-    expect(camera.position.z).toBeCloseTo(-followDistance)
+    expect(pivot.z).toBeCloseTo(0)
+    expect(camera.position.x).toBeCloseTo(10, 1)
+    expect(camera.position.y).toBeCloseTo(cameraHeight, 1)
+    expect(camera.position.z).toBeCloseTo(-followDistance, 1)
     const dir = new THREE.Vector3()
     camera.getWorldDirection(dir)
-    expect(dir.x).toBeCloseTo(0)
-    expect(dir.z).toBeCloseTo(1)
+    expect(dir.x).toBeCloseTo(0, 2)
+    expect(dir.z).toBeCloseTo(1, 2)
   })
 })


### PR DESCRIPTION
## Summary
- implement chase camera that stays behind the median runner using road tangents
- smooth camera motion with a spring-damper filter and prevent obstacle clipping
- add test coverage and bump package version

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68bc3050cf408329b8e2519b50acdda6