### PR TITLE
Improve road adhesion with BVH raycasts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "rouelibre",
-  "version": "0.1.58",
+  "version": "0.1.60",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rouelibre",
-    "version": "0.1.58",
+      "version": "0.1.60",
       "dependencies": {
         "@dimforge/rapier3d-compat": "^0.13.1",
         "daisyui": "^5.0.50",
-        "three": "^0.168.0"
+        "three": "^0.168.0",
+        "three-mesh-bvh": "^0.9.1"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.12",
@@ -3146,6 +3147,15 @@
       "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
       "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw=="
     },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.1.tgz",
+      "integrity": "sha512-WNT+m9jGQgtp4YdtwEnl4oFylNVifRf7iphlwWdJ4bJu7oNkY0xHIyntep9OzHuR1hpe/pyAP840gB/EsYDJfg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5343,6 +5353,12 @@
       "version": "0.168.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.168.0.tgz",
       "integrity": "sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw=="
+    },
+    "three-mesh-bvh": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.9.1.tgz",
+      "integrity": "sha512-WNT+m9jGQgtp4YdtwEnl4oFylNVifRf7iphlwWdJ4bJu7oNkY0xHIyntep9OzHuR1hpe/pyAP840gB/EsYDJfg==",
+      "requires": {}
     },
     "tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.59",
+  "version": "0.1.60",
   "private": true,
   "type": "module",
   "scripts": {
@@ -14,7 +14,8 @@
   "dependencies": {
     "@dimforge/rapier3d-compat": "^0.13.1",
     "daisyui": "^5.0.50",
-    "three": "^0.168.0"
+    "three": "^0.168.0",
+    "three-mesh-bvh": "^0.9.1"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",

--- a/src/systems/adhesion.ts
+++ b/src/systems/adhesion.ts
@@ -1,4 +1,7 @@
 import * as THREE from 'three'
+import { MeshBVH, acceleratedRaycast } from 'three-mesh-bvh'
+
+;(THREE.Mesh.prototype as any).raycast = acceleratedRaycast
 
 export function projectOntoRoad(
   x: number,
@@ -7,22 +10,39 @@ export function projectOntoRoad(
   yaw: number,
   road: THREE.Object3D,
   raycaster: THREE.Raycaster,
-  height = 1
+  footClearance = 1
 ): { position: THREE.Vector3; quaternion: THREE.Quaternion } {
   const origin = new THREE.Vector3(x, y + 100, z)
+  raycaster.firstHitOnly = true
   raycaster.set(origin, new THREE.Vector3(0, -1, 0))
+
+  if ((road as any).isMesh) {
+    const mesh = road as THREE.Mesh
+    const geom = mesh.geometry as THREE.BufferGeometry & { boundsTree?: MeshBVH }
+    if (!geom.boundsTree) {
+      geom.boundsTree = new MeshBVH(geom)
+    }
+  }
+
   const hits = raycaster.intersectObject(road, false)
   if (hits.length > 0) {
     const hit = hits[0]
     const normalMatrix = new THREE.Matrix3().getNormalMatrix(hit.object.matrixWorld)
-    const up = hit.face!.normal.clone().applyMatrix3(normalMatrix).normalize()
-    const pos = hit.point.clone().add(up.clone().multiplyScalar(height))
-    const forward = new THREE.Vector3(Math.sin(yaw), 0, Math.cos(yaw)).normalize()
-    const look = pos.clone().add(forward)
-    const matrix = new THREE.Matrix4().lookAt(pos, look, up)
+    const normal = hit.face!.normal.clone().applyMatrix3(normalMatrix).normalize()
+    const pos = hit.point.clone().add(normal.clone().multiplyScalar(footClearance))
+    let tangent = new THREE.Vector3(Math.sin(yaw), 0, Math.cos(yaw))
+    tangent = tangent.projectOnPlane(normal).normalize()
+    const look = pos.clone().add(tangent)
+    const matrix = new THREE.Matrix4().lookAt(pos, look, normal)
     const quat = new THREE.Quaternion().setFromRotationMatrix(matrix)
     const correction = new THREE.Quaternion().setFromEuler(new THREE.Euler(0, Math.PI / 2, 0))
     quat.multiply(correction)
+
+    const euler = new THREE.Euler().setFromQuaternion(quat, 'YXZ')
+    const maxRoll = THREE.MathUtils.degToRad(45)
+    euler.z = THREE.MathUtils.clamp(euler.z, -maxRoll, maxRoll)
+    quat.setFromEuler(euler)
+
     return { position: pos, quaternion: quat }
   }
   const pos = new THREE.Vector3(x, y, z)
@@ -30,4 +50,28 @@ export function projectOntoRoad(
     new THREE.Euler(0, yaw - Math.PI / 2, 0)
   )
   return { position: pos, quaternion: quat }
+}
+
+export function projectOntoRoadBatch(
+  states: { x: number; y: number; z: number; yaw: number }[],
+  road: THREE.Object3D,
+  raycaster: THREE.Raycaster,
+  footClearance = 1
+): { positions: THREE.Vector3[]; quaternions: THREE.Quaternion[] } {
+  const positions: THREE.Vector3[] = []
+  const quaternions: THREE.Quaternion[] = []
+  for (const s of states) {
+    const { position, quaternion } = projectOntoRoad(
+      s.x,
+      s.y,
+      s.z,
+      s.yaw,
+      road,
+      raycaster,
+      footClearance
+    )
+    positions.push(position)
+    quaternions.push(quaternion)
+  }
+  return { positions, quaternions }
 }

--- a/test/adhesion.test.ts
+++ b/test/adhesion.test.ts
@@ -16,4 +16,15 @@ describe('adhesion', () => {
     const normal = new THREE.Vector3(0, 0, 1).applyMatrix3(normalMatrix).normalize()
     expect(up.angleTo(normal)).toBeLessThan(THREE.MathUtils.degToRad(2))
   })
+
+  it('places rider within 1cm of target altitude', () => {
+    const geom = new THREE.PlaneGeometry(10, 10)
+    const mesh = new THREE.Mesh(geom)
+    mesh.rotateX(-Math.PI / 2)
+    mesh.updateMatrixWorld()
+    const raycaster = new THREE.Raycaster()
+    const footClearance = 1
+    const { position } = projectOntoRoad(0, 5, 0, 0, mesh, raycaster, footClearance)
+    expect(Math.abs(position.y - footClearance)).toBeLessThan(0.01)
+  })
 })


### PR DESCRIPTION
## Summary
- Use three-mesh-bvh to accelerate vertical road raycasts
- Align rider orientation with road tangent and clamp excessive roll
- Test altitude accuracy within 1 cm

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68be7cc7f39483299403e37373a4aa91