### PR TITLE
Moteur longitudinal minimal pour coureur isolé (route plate)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,13 +2,22 @@
 
 ## Vue d'ensemble
 
-Le dépôt est organisé en workspace pnpm. Le socle actuel contient uniquement les éléments nécessaires aux vérifications reproductibles et au futur noyau de simulation.
+Le dépôt est organisé en workspace pnpm. Le socle contient les éléments nécessaires aux vérifications reproductibles et au noyau de simulation longitudinal minimal.
 
 ## Packages
 
 ### `packages/sim-core`
 
-`sim-core` est le package destiné au futur moteur de simulation. Dans l'état actuel, il fournit seulement un marqueur typé vérifié par Vitest afin de valider la chaîne TypeScript et test.
+`sim-core` contient le moteur de simulation sans dépendance graphique, navigateur, DOM, React, Three.js ni moteur de corps rigides.
+
+API exposée :
+
+- `SingleRiderProfile` décrit le couple coureur-vélo avec masses, CdA, coefficient de roulement, rendement mécanique, puissance maximale et limite de force propulsive basse vitesse.
+- `FlatRoadEnvironment` décrit l'air, le vent longitudinal et la gravité.
+- `SingleRiderState` contient l'état dynamique mutable.
+- `createSingleRiderState` crée un état initial typé.
+- `computeSingleRiderForces` calcule les forces longitudinales instantanées.
+- `stepSingleRider` avance un état d'un pas temporel explicite.
 
 Contraintes :
 
@@ -16,7 +25,8 @@ Contraintes :
 - pas de dépendance à Three.js ;
 - pas de dépendance au DOM ou au navigateur ;
 - pas de dépendance graphique ;
-- pas d'utilisation directe de `Math.random()` dans le futur code de simulation.
+- pas d'utilisation directe de `Math.random()` dans le code de simulation ;
+- unités SI dans le moteur.
 
 ## Scripts racine
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ API exposée :
 - `SingleRiderState` contient l'état dynamique mutable.
 - `createSingleRiderState` crée un état initial typé.
 - `computeSingleRiderForces` calcule les forces longitudinales instantanées.
-- `stepSingleRider` avance un état d'un pas temporel explicite.
+- `stepSingleRider` valide les entrées publiques puis avance un état d'un pas temporel explicite.
 
 Contraintes :
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,9 +1,40 @@
 # Benchmarks
 
-## Statut
+## Scénario de référence : coureur isolé sur route plate
 
-Aucun benchmark de simulation n'existe.
+Le scénario de référence exécute le moteur longitudinal minimal pendant 7 200 s avec un pas de 0,5 s. Les vitesses reportées correspondent à l'état final, utilisé comme approximation de vitesse stabilisée pour ces paramètres.
 
-## Politique prévue
+Paramètres coureur-vélo :
 
-Les benchmarks seront ajoutés avec les fonctionnalités mesurables correspondantes. Chaque benchmark devra préciser le scénario, les métriques, l'environnement d'exécution et les limites d'interprétation.
+| Paramètre | Valeur |
+| --- | ---: |
+| Masse coureur | 75 kg |
+| Masse vélo | 8 kg |
+| CdA | 0,32 m² |
+| Coefficient de résistance au roulement | 0,004 |
+| Rendement mécanique | 0,97 |
+| Puissance maximale | 1 200 W |
+| Force propulsive maximale | 1 200 N |
+
+Paramètres environnement :
+
+| Paramètre | Valeur |
+| --- | ---: |
+| Densité de l'air | 1,225 kg/m³ |
+| Gravité | 9,80665 m/s² |
+| Durée | 7 200 s |
+| Pas de temps | 0,5 s |
+
+Convention du vent : valeur positive pour un vent de face, valeur négative pour un vent arrière.
+
+| Cas | Vent | Vitesse stabilisée | Vitesse stabilisée |
+| --- | ---: | ---: | ---: |
+| 200 W sans vent | 0 m/s | 9,411 m/s | 33,88 km/h |
+| 250 W sans vent | 0 m/s | 10,220 m/s | 36,79 km/h |
+| 300 W sans vent | 0 m/s | 10,923 m/s | 39,32 km/h |
+| 250 W avec vent de face | +3 m/s | 8,418 m/s | 30,30 km/h |
+| 250 W avec vent arrière | -3 m/s | 12,206 m/s | 43,94 km/h |
+
+## Limites d'interprétation
+
+Ces résultats valident uniquement le comportement numérique du modèle longitudinal plat avec les paramètres indiqués. Ils ne constituent pas une validation physiologique ou aérodynamique complète.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -14,7 +14,7 @@ Paramètres coureur-vélo :
 | Coefficient de résistance au roulement | 0,004 |
 | Rendement mécanique | 0,97 |
 | Puissance maximale | 1 200 W |
-| Force propulsive maximale | 1 200 N |
+| Force propulsive maximale | 200 N |
 
 Paramètres environnement :
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -20,4 +20,4 @@ Le projet ne contient pas de modèle d'énergie, puissance critique, fatigue, r�
 
 ## Prochaine tâche unique
 
-La prochaine tâche doit rester limitée à un seul sujet explicitement demandé. Le moteur longitudinal plat constitue le seul comportement de simulation cycliste implémenté et testé.
+Implémenter le modèle énergétique minimal du coureur isolé avec puissance critique, réserve anaérobie, consommation et récupération. Cette tâche n’est pas implémentée dans la PR du moteur longitudinal plat.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Phase actuelle
 
-Roue libre est en phase de fondation technique et documentaire.
+Roue libre est en phase de fondation technique, documentaire et physique minimale.
 
 ## Existant
 
@@ -10,13 +10,14 @@ Roue libre est en phase de fondation technique et documentaire.
 - Configuration TypeScript stricte partagée.
 - Configuration Vitest via le package `sim-core`.
 - Package `packages/sim-core` sans dépendance graphique, navigateur, DOM, React ou Three.js.
+- Moteur longitudinal déterministe minimal pour un coureur isolé sur route plate.
 - Vérification CI pour l'installation, le typecheck et les tests sur Pull Request.
-- Documentation initiale du projet.
+- Documentation initiale du projet et du modèle physique longitudinal.
 
 ## Non existant
 
-Aucune fonctionnalité de simulation cycliste n'est implémentée, validée ou exposée. Le projet ne contient pas de modèle physique, énergie, intelligence artificielle, aspiration, import GPX, rendu graphique ou exécution Web Worker.
+Le projet ne contient pas de modèle d'énergie, puissance critique, fatigue, récupération, pente, GPX, virages, position latérale, aspiration, intelligence artificielle, rendu graphique, exécution Web Worker ou moteur de corps rigides.
 
 ## Prochaine tâche unique
 
-Implémenter le moteur déterministe minimal d'un coureur isolé sur route plate.
+La prochaine tâche doit rester limitée à un seul sujet explicitement demandé. Le moteur longitudinal plat constitue le seul comportement de simulation cycliste implémenté et testé.

--- a/docs/SIMULATION_MODEL.md
+++ b/docs/SIMULATION_MODEL.md
@@ -31,7 +31,7 @@ Les paramètres de référence exposés par `defaultSingleRiderProfile` et `defa
 | Coefficient de résistance au roulement | 0,004 |
 | Rendement mécanique | 0,97 |
 | Puissance maximale | 1 200 W |
-| Force propulsive maximale | 1 200 N |
+| Force propulsive maximale | 200 N |
 | Densité de l'air | 1,225 kg/m³ |
 | Vent longitudinal | 0 m/s |
 | Gravité | 9,80665 m/s² |
@@ -78,7 +78,7 @@ La force propulsive basse vitesse utilise une limite explicite :
 F_prop = min(P_roue / max(v, P_roue / F_prop_max), F_prop_max)
 ```
 
-Si `P_roue` vaut zéro, `F_prop` vaut zéro. Cette méthode évite la division par zéro, garantit des nombres finis, limite l'accélération au démarrage et permet un départ depuis l'arrêt sans dépendance temporelle cachée.
+Si `P_roue` vaut zéro, `F_prop` vaut zéro. La limite par défaut vaut 200 N. Avec le profil de référence de 83 kg, elle borne l'accélération propulsive initiale sous 3 m/s² en tenant compte de la résistance au roulement, tout en permettant un départ progressif depuis l'arrêt. Cette méthode évite la division par zéro, garantit des nombres finis et ne dépend pas d'un pas de temps caché.
 
 La traînée aérodynamique signée est :
 
@@ -117,11 +117,26 @@ distance_suivante = distance + ((v + v_suivante) / 2) * dt
 
 Le temps simulé augmente de `dt`.
 
+L'accélération exposée dans `SingleRiderState.accelerationMetersPerSecondSquared` correspond à l'accélération effectivement appliquée à la vitesse après bornage :
+
+```text
+a_appliquee = (v_suivante - v) / dt
+```
+
+Cette définition rend l'état cohérent avec l'évolution observée de la vitesse. Un coureur immobile qui reste à vitesse nulle après bornage expose donc une accélération appliquée nulle, même si la somme théorique des forces pointe vers l'arrière.
+
+## Validation des entrées
+
+Les données publiques sont validées avant mutation de l'état. Les contraintes minimales sont : masse coureur strictement positive, masse vélo positive ou nulle, masse totale strictement positive, CdA positif ou nul, coefficient de roulement positif ou nul, rendement mécanique entre 0 et 1, puissance maximale positive ou nulle, force propulsive maximale strictement positive, densité de l'air positive ou nulle, gravité strictement positive, vent fini, état fini, temps, distance et vitesse non négatifs, puissance demandée finie et `dt` strictement positif.
+
+Une entrée invalide lève une `RangeError` avec le nom du champ concerné avant toute mutation de l'état.
+
 ## Invariants couverts par les tests
 
 Les tests vérifient :
 
 - démarrage depuis l'arrêt sans `NaN` ni infini ;
+- démarrage progressif à 60 Hz avec accélération initiale inférieure ou égale à 3 m/s² ;
 - vitesse jamais négative ;
 - distance non décroissante ;
 - puissance produite plafonnée ;
@@ -129,6 +144,9 @@ Les tests vérifient :
 - effet cohérent du vent de face et du vent arrière ;
 - décélération sans puissance ;
 - déterminisme exact pour des entrées identiques ;
+- validation des entrées invalides sans mutation ;
+- vitesses stabilisées de référence avec tolérances explicites ;
+- accélération appliquée cohérente avec la vitesse bornée ;
 - valeurs finies sur simulation longue.
 
 ## Simplifications et limites

--- a/docs/SIMULATION_MODEL.md
+++ b/docs/SIMULATION_MODEL.md
@@ -2,12 +2,135 @@
 
 ## Statut
 
-Aucun modèle de simulation cycliste n'est implémenté ou validé.
+Le modèle implémenté couvre uniquement la physique longitudinale minimale d'un coureur isolé sur route plate. Il calcule l'évolution de la vitesse et de la distance à partir de la puissance demandée, du profil coureur-vélo, de l'environnement et d'un pas de temps explicite.
 
-## Principes prévus
+## Unités
 
-Les futures implémentations du moteur utilisent les unités SI et évitent les sources de hasard implicites. Le code de simulation ne doit pas appeler directement `Math.random()` ; toute variabilité doit passer par une abstraction déterministe et testable.
+Le moteur utilise les unités SI :
 
-## Prochaine étape prévue
+- temps : seconde (`s`) ;
+- distance : mètre (`m`) ;
+- vitesse : mètre par seconde (`m/s`) ;
+- accélération : mètre par seconde carrée (`m/s²`) ;
+- masse : kilogramme (`kg`) ;
+- puissance : watt (`W`) ;
+- force : newton (`N`) ;
+- densité de l'air : kilogramme par mètre cube (`kg/m³`) ;
+- gravité : mètre par seconde carrée (`m/s²`) ;
+- CdA : mètre carré (`m²`).
 
-La prochaine tâche projet est le moteur déterministe minimal d'un coureur isolé sur route plate. Cette étape reste hors du périmètre du socle actuel.
+## Paramètres par défaut
+
+Les paramètres de référence exposés par `defaultSingleRiderProfile` et `defaultFlatRoadEnvironment` sont :
+
+| Paramètre | Valeur |
+| --- | ---: |
+| Masse coureur | 75 kg |
+| Masse vélo | 8 kg |
+| CdA | 0,32 m² |
+| Coefficient de résistance au roulement | 0,004 |
+| Rendement mécanique | 0,97 |
+| Puissance maximale | 1 200 W |
+| Force propulsive maximale | 1 200 N |
+| Densité de l'air | 1,225 kg/m³ |
+| Vent longitudinal | 0 m/s |
+| Gravité | 9,80665 m/s² |
+
+## Convention du vent
+
+Le vent longitudinal est exprimé dans le repère de déplacement du coureur :
+
+- valeur positive : vent de face ;
+- valeur négative : vent arrière ;
+- zéro : absence de vent longitudinal.
+
+La vitesse relative de l'air est :
+
+```text
+v_air = v + v_vent
+```
+
+avec `v` la vitesse du coureur et `v_vent` le vent longitudinal. Une vitesse relative positive produit une traînée opposée au déplacement. Une vitesse relative négative représente un vent arrière plus rapide que le coureur et produit une force aérodynamique signée dans le sens du déplacement.
+
+## Équations
+
+La masse totale est :
+
+```text
+m = m_coureur + m_velo
+```
+
+La puissance effectivement produite est bornée :
+
+```text
+P = min(max(P_demandee, 0), P_max)
+```
+
+La puissance à la roue tient compte du rendement mécanique :
+
+```text
+P_roue = P * rendement
+```
+
+La force propulsive basse vitesse utilise une limite explicite :
+
+```text
+F_prop = min(P_roue / max(v, P_roue / F_prop_max), F_prop_max)
+```
+
+Si `P_roue` vaut zéro, `F_prop` vaut zéro. Cette méthode évite la division par zéro, garantit des nombres finis, limite l'accélération au démarrage et permet un départ depuis l'arrêt sans dépendance temporelle cachée.
+
+La traînée aérodynamique signée est :
+
+```text
+F_aero = 0,5 * rho * CdA * v_air * abs(v_air)
+```
+
+La résistance au roulement sur route plate est :
+
+```text
+F_rr = Crr * m * g
+```
+
+Elle s'applique lorsque le coureur avance ou lorsqu'une force propulsive est produite. À l'arrêt sans puissance, elle vaut zéro pour éviter une accélération négative artificielle.
+
+La force nette et l'accélération sont :
+
+```text
+F_net = F_prop - F_aero - F_rr
+a = F_net / m
+```
+
+## Méthode d'intégration
+
+Chaque pas utilise un pas temporel explicite `dt` strictement positif. La vitesse suivante est calculée par Euler explicite puis bornée à zéro :
+
+```text
+v_suivante = max(0, v + a * dt)
+```
+
+La distance utilise la vitesse moyenne du pas :
+
+```text
+distance_suivante = distance + ((v + v_suivante) / 2) * dt
+```
+
+Le temps simulé augmente de `dt`.
+
+## Invariants couverts par les tests
+
+Les tests vérifient :
+
+- démarrage depuis l'arrêt sans `NaN` ni infini ;
+- vitesse jamais négative ;
+- distance non décroissante ;
+- puissance produite plafonnée ;
+- vitesse stabilisée plus élevée à 300 W qu'à 200 W ;
+- effet cohérent du vent de face et du vent arrière ;
+- décélération sans puissance ;
+- déterminisme exact pour des entrées identiques ;
+- valeurs finies sur simulation longue.
+
+## Simplifications et limites
+
+Le modèle ne couvre pas la pente, l'altitude, les virages, la position latérale, l'aspiration, la fatigue, la récupération, la réserve anaérobie, la puissance critique, les changements de posture, les pertes dépendantes de la transmission, le freinage, l'adhérence, les collisions, le GPX, l'intelligence artificielle, le rendu graphique ou l'exécution Web Worker.

--- a/packages/sim-core/src/index.ts
+++ b/packages/sim-core/src/index.ts
@@ -16,7 +16,7 @@ export interface SingleRiderProfile {
    * Limite explicite de force propulsive à très basse vitesse.
    * Elle évite qu'une puissance finie produise une force infinie à l'arrêt.
    */
-  maxPropulsiveForceNewtons?: number;
+  maxPropulsiveForceNewtons: number;
 }
 
 /** Environnement longitudinal plat, en unités SI. */
@@ -59,7 +59,7 @@ export const defaultSingleRiderProfile: SingleRiderProfile = {
   rollingResistanceCoefficient: 0.004,
   mechanicalEfficiency: 0.97,
   maxPowerWatts: 1_200,
-  maxPropulsiveForceNewtons: 1_200,
+  maxPropulsiveForceNewtons: 200,
 };
 
 export const defaultFlatRoadEnvironment: FlatRoadEnvironment = {
@@ -72,6 +72,61 @@ function assertFinite(name: string, value: number): void {
   if (!Number.isFinite(value)) {
     throw new RangeError(`${name} must be finite`);
   }
+}
+
+function assertNonNegative(name: string, value: number): void {
+  assertFinite(name, value);
+  if (value < 0) {
+    throw new RangeError(`${name} must be greater than or equal to zero`);
+  }
+}
+
+function assertPositive(name: string, value: number): void {
+  assertFinite(name, value);
+  if (value <= 0) {
+    throw new RangeError(`${name} must be greater than zero`);
+  }
+}
+
+function validateProfile(profile: SingleRiderProfile): void {
+  assertPositive("profile.riderMassKg", profile.riderMassKg);
+  assertNonNegative("profile.bikeMassKg", profile.bikeMassKg);
+  assertPositive("profile.totalMassKg", profile.riderMassKg + profile.bikeMassKg);
+  assertNonNegative("profile.cdaSquareMeters", profile.cdaSquareMeters);
+  assertNonNegative("profile.rollingResistanceCoefficient", profile.rollingResistanceCoefficient);
+  assertFinite("profile.mechanicalEfficiency", profile.mechanicalEfficiency);
+  if (profile.mechanicalEfficiency < 0 || profile.mechanicalEfficiency > 1) {
+    throw new RangeError("profile.mechanicalEfficiency must be between 0 and 1");
+  }
+  assertNonNegative("profile.maxPowerWatts", profile.maxPowerWatts);
+  assertPositive("profile.maxPropulsiveForceNewtons", profile.maxPropulsiveForceNewtons);
+}
+
+function validateEnvironment(environment: FlatRoadEnvironment): void {
+  assertNonNegative("environment.airDensityKgPerCubicMeter", environment.airDensityKgPerCubicMeter);
+  assertFinite("environment.windSpeedMetersPerSecond", environment.windSpeedMetersPerSecond);
+  assertPositive("environment.gravityMetersPerSecondSquared", environment.gravityMetersPerSecondSquared);
+}
+
+function validateState(state: SingleRiderState): void {
+  assertNonNegative("state.timeSeconds", state.timeSeconds);
+  assertNonNegative("state.distanceMeters", state.distanceMeters);
+  assertNonNegative("state.speedMetersPerSecond", state.speedMetersPerSecond);
+  assertFinite("state.accelerationMetersPerSecondSquared", state.accelerationMetersPerSecondSquared);
+  assertFinite("state.requestedPowerWatts", state.requestedPowerWatts);
+  assertNonNegative("state.producedPowerWatts", state.producedPowerWatts);
+}
+
+function validateStepInputs(
+  state: SingleRiderState,
+  profile: SingleRiderProfile,
+  environment: FlatRoadEnvironment,
+  dtSeconds: number,
+): void {
+  validateState(state);
+  validateProfile(profile);
+  validateEnvironment(environment);
+  assertPositive("dtSeconds", dtSeconds);
 }
 
 function clamp(value: number, minimum: number, maximum: number): number {
@@ -96,9 +151,13 @@ export function computeSingleRiderForces(
   profile: SingleRiderProfile,
   environment: FlatRoadEnvironment,
 ): SingleRiderForces {
+  validateState(state);
+  validateProfile(profile);
+  validateEnvironment(environment);
+
   const totalMassKg = profile.riderMassKg + profile.bikeMassKg;
   const producedPowerWatts = clamp(state.requestedPowerWatts, 0, profile.maxPowerWatts);
-  const maxPropulsiveForceNewtons = profile.maxPropulsiveForceNewtons ?? 1_200;
+  const maxPropulsiveForceNewtons = profile.maxPropulsiveForceNewtons;
   const effectivePowerWatts = producedPowerWatts * profile.mechanicalEfficiency;
   const forceFromPowerNewtons = effectivePowerWatts > 0
     ? effectivePowerWatts / Math.max(state.speedMetersPerSecond, effectivePowerWatts / maxPropulsiveForceNewtons)
@@ -135,10 +194,7 @@ export function stepSingleRider(
   environment: FlatRoadEnvironment,
   dtSeconds: number,
 ): void {
-  assertFinite("dtSeconds", dtSeconds);
-  if (dtSeconds <= 0) {
-    throw new RangeError("dtSeconds must be greater than zero");
-  }
+  validateStepInputs(state, profile, environment, dtSeconds);
 
   const forces = computeSingleRiderForces(state, profile, environment);
   const previousSpeedMetersPerSecond = Math.max(0, state.speedMetersPerSecond);
@@ -150,7 +206,7 @@ export function stepSingleRider(
   state.timeSeconds += dtSeconds;
   state.distanceMeters += ((previousSpeedMetersPerSecond + nextSpeedMetersPerSecond) / 2) * dtSeconds;
   state.speedMetersPerSecond = nextSpeedMetersPerSecond;
-  state.accelerationMetersPerSecondSquared = forces.accelerationMetersPerSecondSquared;
+  state.accelerationMetersPerSecondSquared = (nextSpeedMetersPerSecond - previousSpeedMetersPerSecond) / dtSeconds;
   state.producedPowerWatts = forces.producedPowerWatts;
 
   assertFinite("timeSeconds", state.timeSeconds);

--- a/packages/sim-core/src/index.ts
+++ b/packages/sim-core/src/index.ts
@@ -3,3 +3,159 @@ export const simCorePackageName = "@rouelibre/sim-core";
 export function describeFoundation(): string {
   return "Roue libre simulation core foundation";
 }
+
+/** Profil physique minimal d'un coureur et de son vélo, en unités SI. */
+export interface SingleRiderProfile {
+  riderMassKg: number;
+  bikeMassKg: number;
+  cdaSquareMeters: number;
+  rollingResistanceCoefficient: number;
+  mechanicalEfficiency: number;
+  maxPowerWatts: number;
+  /**
+   * Limite explicite de force propulsive à très basse vitesse.
+   * Elle évite qu'une puissance finie produise une force infinie à l'arrêt.
+   */
+  maxPropulsiveForceNewtons?: number;
+}
+
+/** Environnement longitudinal plat, en unités SI. */
+export interface FlatRoadEnvironment {
+  airDensityKgPerCubicMeter: number;
+  /**
+   * Vent longitudinal en m/s. Convention: valeur positive = vent de face,
+   * valeur négative = vent arrière. La vitesse relative de l'air vaut
+   * speedMetersPerSecond + windSpeedMetersPerSecond.
+   */
+  windSpeedMetersPerSecond: number;
+  gravityMetersPerSecondSquared: number;
+}
+
+/** État dynamique mutable d'un coureur isolé, en unités SI. */
+export interface SingleRiderState {
+  timeSeconds: number;
+  distanceMeters: number;
+  speedMetersPerSecond: number;
+  accelerationMetersPerSecondSquared: number;
+  requestedPowerWatts: number;
+  producedPowerWatts: number;
+}
+
+export interface SingleRiderForces {
+  totalMassKg: number;
+  producedPowerWatts: number;
+  propulsiveForceNewtons: number;
+  relativeAirSpeedMetersPerSecond: number;
+  aerodynamicDragForceNewtons: number;
+  rollingResistanceForceNewtons: number;
+  netForceNewtons: number;
+  accelerationMetersPerSecondSquared: number;
+}
+
+export const defaultSingleRiderProfile: SingleRiderProfile = {
+  riderMassKg: 75,
+  bikeMassKg: 8,
+  cdaSquareMeters: 0.32,
+  rollingResistanceCoefficient: 0.004,
+  mechanicalEfficiency: 0.97,
+  maxPowerWatts: 1_200,
+  maxPropulsiveForceNewtons: 1_200,
+};
+
+export const defaultFlatRoadEnvironment: FlatRoadEnvironment = {
+  airDensityKgPerCubicMeter: 1.225,
+  windSpeedMetersPerSecond: 0,
+  gravityMetersPerSecondSquared: 9.80665,
+};
+
+function assertFinite(name: string, value: number): void {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`${name} must be finite`);
+  }
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value));
+}
+
+export function createSingleRiderState(requestedPowerWatts: number): SingleRiderState {
+  assertFinite("requestedPowerWatts", requestedPowerWatts);
+
+  return {
+    timeSeconds: 0,
+    distanceMeters: 0,
+    speedMetersPerSecond: 0,
+    accelerationMetersPerSecondSquared: 0,
+    requestedPowerWatts,
+    producedPowerWatts: 0,
+  };
+}
+
+export function computeSingleRiderForces(
+  state: SingleRiderState,
+  profile: SingleRiderProfile,
+  environment: FlatRoadEnvironment,
+): SingleRiderForces {
+  const totalMassKg = profile.riderMassKg + profile.bikeMassKg;
+  const producedPowerWatts = clamp(state.requestedPowerWatts, 0, profile.maxPowerWatts);
+  const maxPropulsiveForceNewtons = profile.maxPropulsiveForceNewtons ?? 1_200;
+  const effectivePowerWatts = producedPowerWatts * profile.mechanicalEfficiency;
+  const forceFromPowerNewtons = effectivePowerWatts > 0
+    ? effectivePowerWatts / Math.max(state.speedMetersPerSecond, effectivePowerWatts / maxPropulsiveForceNewtons)
+    : 0;
+  const propulsiveForceNewtons = Math.min(forceFromPowerNewtons, maxPropulsiveForceNewtons);
+  const relativeAirSpeedMetersPerSecond = state.speedMetersPerSecond + environment.windSpeedMetersPerSecond;
+  const aerodynamicDragForceNewtons = 0.5
+    * environment.airDensityKgPerCubicMeter
+    * profile.cdaSquareMeters
+    * relativeAirSpeedMetersPerSecond
+    * Math.abs(relativeAirSpeedMetersPerSecond);
+  const rollingResistanceForceNewtons = profile.rollingResistanceCoefficient
+    * totalMassKg
+    * environment.gravityMetersPerSecondSquared
+    * (state.speedMetersPerSecond > 0 || propulsiveForceNewtons > 0 ? 1 : 0);
+  const netForceNewtons = propulsiveForceNewtons - aerodynamicDragForceNewtons - rollingResistanceForceNewtons;
+  const accelerationMetersPerSecondSquared = netForceNewtons / totalMassKg;
+
+  return {
+    totalMassKg,
+    producedPowerWatts,
+    propulsiveForceNewtons,
+    relativeAirSpeedMetersPerSecond,
+    aerodynamicDragForceNewtons,
+    rollingResistanceForceNewtons,
+    netForceNewtons,
+    accelerationMetersPerSecondSquared,
+  };
+}
+
+export function stepSingleRider(
+  state: SingleRiderState,
+  profile: SingleRiderProfile,
+  environment: FlatRoadEnvironment,
+  dtSeconds: number,
+): void {
+  assertFinite("dtSeconds", dtSeconds);
+  if (dtSeconds <= 0) {
+    throw new RangeError("dtSeconds must be greater than zero");
+  }
+
+  const forces = computeSingleRiderForces(state, profile, environment);
+  const previousSpeedMetersPerSecond = Math.max(0, state.speedMetersPerSecond);
+  const nextSpeedMetersPerSecond = Math.max(
+    0,
+    previousSpeedMetersPerSecond + forces.accelerationMetersPerSecondSquared * dtSeconds,
+  );
+
+  state.timeSeconds += dtSeconds;
+  state.distanceMeters += ((previousSpeedMetersPerSecond + nextSpeedMetersPerSecond) / 2) * dtSeconds;
+  state.speedMetersPerSecond = nextSpeedMetersPerSecond;
+  state.accelerationMetersPerSecondSquared = forces.accelerationMetersPerSecondSquared;
+  state.producedPowerWatts = forces.producedPowerWatts;
+
+  assertFinite("timeSeconds", state.timeSeconds);
+  assertFinite("distanceMeters", state.distanceMeters);
+  assertFinite("speedMetersPerSecond", state.speedMetersPerSecond);
+  assertFinite("accelerationMetersPerSecondSquared", state.accelerationMetersPerSecondSquared);
+  assertFinite("producedPowerWatts", state.producedPowerWatts);
+}

--- a/packages/sim-core/test/single-rider.test.ts
+++ b/packages/sim-core/test/single-rider.test.ts
@@ -18,7 +18,7 @@ const referenceProfile: SingleRiderProfile = {
   rollingResistanceCoefficient: 0.004,
   mechanicalEfficiency: 0.97,
   maxPowerWatts: 1_200,
-  maxPropulsiveForceNewtons: 1_200,
+  maxPropulsiveForceNewtons: 200,
 };
 
 const referenceEnvironment: FlatRoadEnvironment = {
@@ -28,12 +28,20 @@ const referenceEnvironment: FlatRoadEnvironment = {
   gravityMetersPerSecondSquared: 9.80665,
 };
 
+// Les valeurs de référence sont documentées au millième de m/s.
+const stabilizedSpeedToleranceMetersPerSecond = 0.001;
+const convergenceToleranceMetersPerSecond = 0.001;
+
 function expectFiniteState(state: SingleRiderState): void {
   expect(Number.isFinite(state.timeSeconds)).toBe(true);
   expect(Number.isFinite(state.distanceMeters)).toBe(true);
   expect(Number.isFinite(state.speedMetersPerSecond)).toBe(true);
   expect(Number.isFinite(state.accelerationMetersPerSecondSquared)).toBe(true);
   expect(Number.isFinite(state.producedPowerWatts)).toBe(true);
+}
+
+function cloneState(state: SingleRiderState): SingleRiderState {
+  return { ...state };
 }
 
 function simulate(
@@ -60,6 +68,29 @@ function simulate(
   return state;
 }
 
+function simulateWithPreviousSpeed(
+  powerWatts: number,
+  durationSeconds: number,
+  dtSeconds: number,
+  environment: FlatRoadEnvironment = referenceEnvironment,
+  previousWindowSeconds = 60,
+): { finalState: SingleRiderState; previousWindowSpeed: number } {
+  const state = createSingleRiderState(powerWatts);
+  const steps = Math.trunc(durationSeconds / dtSeconds);
+  const previousWindowStep = steps - Math.trunc(previousWindowSeconds / dtSeconds);
+  let previousWindowSpeed = state.speedMetersPerSecond;
+
+  for (let index = 0; index < steps; index += 1) {
+    if (index === previousWindowStep) {
+      previousWindowSpeed = state.speedMetersPerSecond;
+    }
+
+    stepSingleRider(state, referenceProfile, environment, dtSeconds);
+  }
+
+  return { finalState: state, previousWindowSpeed };
+}
+
 describe("single rider longitudinal physics", () => {
   it("starts from rest without NaN or infinite values", () => {
     const state = createSingleRiderState(250);
@@ -69,6 +100,18 @@ describe("single rider longitudinal physics", () => {
     expectFiniteState(state);
     expect(state.speedMetersPerSecond).toBeGreaterThan(0);
     expect(state.distanceMeters).toBeGreaterThan(0);
+  });
+
+  it("starts progressively at 60 Hz with bounded acceleration and speed", () => {
+    const state = createSingleRiderState(250);
+    const dtSeconds = 1 / 60;
+
+    stepSingleRider(state, referenceProfile, referenceEnvironment, dtSeconds);
+
+    expectFiniteState(state);
+    expect(state.accelerationMetersPerSecondSquared).toBeGreaterThan(0);
+    expect(state.accelerationMetersPerSecondSquared).toBeLessThanOrEqual(3);
+    expect(state.speedMetersPerSecond).toBeLessThanOrEqual(3 * dtSeconds);
   });
 
   it("keeps speed non-negative while coasting under resistance", () => {
@@ -132,6 +175,18 @@ describe("single rider longitudinal physics", () => {
     expect(state.accelerationMetersPerSecondSquared).toBeLessThan(0);
   });
 
+  it("keeps exposed acceleration consistent with clamped speed at rest", () => {
+    const state = createSingleRiderState(0);
+
+    stepSingleRider(state, referenceProfile, {
+      ...referenceEnvironment,
+      windSpeedMetersPerSecond: 3,
+    }, 0.5);
+
+    expect(state.speedMetersPerSecond).toBe(0);
+    expect(state.accelerationMetersPerSecondSquared).toBe(0);
+  });
+
   it("is deterministic for identical inputs", () => {
     const first = simulate(250, 3_600, 0.5, {
       ...referenceEnvironment,
@@ -150,5 +205,65 @@ describe("single rider longitudinal physics", () => {
 
     expectFiniteState(state);
     expect(state.timeSeconds).toBe(86_400);
+  });
+
+  it.each([
+    ["200 W sans vent", 200, 0, 9.411],
+    ["250 W sans vent", 250, 0, 10.220],
+    ["300 W sans vent", 300, 0, 10.923],
+    ["250 W vent de face", 250, 3, 8.418],
+    ["250 W vent arrière", 250, -3, 12.206],
+  ])("matches the documented stabilized speed for %s", (_label, powerWatts, windSpeedMetersPerSecond, expectedSpeed) => {
+    const { finalState, previousWindowSpeed } = simulateWithPreviousSpeed(powerWatts, 7_200, 0.5, {
+      ...referenceEnvironment,
+      windSpeedMetersPerSecond,
+    });
+
+    expect(Math.abs(finalState.speedMetersPerSecond - expectedSpeed)).toBeLessThanOrEqual(
+      stabilizedSpeedToleranceMetersPerSecond,
+    );
+    expect(Math.abs(finalState.speedMetersPerSecond - previousWindowSpeed)).toBeLessThan(
+      convergenceToleranceMetersPerSecond,
+    );
+  });
+});
+
+describe("single rider input validation", () => {
+  it.each([
+    ["zero total mass", { riderMassKg: 0, bikeMassKg: 0 }, /profile\.riderMassKg/],
+    ["negative maximum power", { maxPowerWatts: -1 }, /profile\.maxPowerWatts/],
+    ["efficiency below zero", { mechanicalEfficiency: -0.1 }, /profile\.mechanicalEfficiency/],
+    ["efficiency above one", { mechanicalEfficiency: 1.1 }, /profile\.mechanicalEfficiency/],
+    ["zero maximum propulsive force", { maxPropulsiveForceNewtons: 0 }, /profile\.maxPropulsiveForceNewtons/],
+    ["NaN CdA", { cdaSquareMeters: Number.NaN }, /profile\.cdaSquareMeters/],
+  ])("rejects invalid profile input: %s", (_label, profilePatch, expectedMessage) => {
+    const state = createSingleRiderState(250);
+    const before = cloneState(state);
+
+    expect(() => {
+      stepSingleRider(state, { ...referenceProfile, ...profilePatch }, referenceEnvironment, 0.5);
+    }).toThrow(expectedMessage);
+    expect(state).toStrictEqual(before);
+  });
+
+  it.each([0, -0.5])("rejects a non-positive dt without mutating state: %s", (dtSeconds) => {
+    const state = createSingleRiderState(250);
+    const before = cloneState(state);
+
+    expect(() => {
+      stepSingleRider(state, referenceProfile, referenceEnvironment, dtSeconds);
+    }).toThrow(/dtSeconds/);
+    expect(state).toStrictEqual(before);
+  });
+
+  it("rejects invalid state values before mutation", () => {
+    const state = createSingleRiderState(250);
+    state.distanceMeters = Number.NaN;
+    const before = cloneState(state);
+
+    expect(() => {
+      stepSingleRider(state, referenceProfile, referenceEnvironment, 0.5);
+    }).toThrow(/state\.distanceMeters/);
+    expect(state).toStrictEqual(before);
   });
 });

--- a/packages/sim-core/test/single-rider.test.ts
+++ b/packages/sim-core/test/single-rider.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createSingleRiderState,
+  defaultFlatRoadEnvironment,
+  defaultSingleRiderProfile,
+  stepSingleRider,
+  type FlatRoadEnvironment,
+  type SingleRiderProfile,
+  type SingleRiderState,
+} from "../src/index.js";
+
+const referenceProfile: SingleRiderProfile = {
+  ...defaultSingleRiderProfile,
+  riderMassKg: 75,
+  bikeMassKg: 8,
+  cdaSquareMeters: 0.32,
+  rollingResistanceCoefficient: 0.004,
+  mechanicalEfficiency: 0.97,
+  maxPowerWatts: 1_200,
+  maxPropulsiveForceNewtons: 1_200,
+};
+
+const referenceEnvironment: FlatRoadEnvironment = {
+  ...defaultFlatRoadEnvironment,
+  airDensityKgPerCubicMeter: 1.225,
+  windSpeedMetersPerSecond: 0,
+  gravityMetersPerSecondSquared: 9.80665,
+};
+
+function expectFiniteState(state: SingleRiderState): void {
+  expect(Number.isFinite(state.timeSeconds)).toBe(true);
+  expect(Number.isFinite(state.distanceMeters)).toBe(true);
+  expect(Number.isFinite(state.speedMetersPerSecond)).toBe(true);
+  expect(Number.isFinite(state.accelerationMetersPerSecondSquared)).toBe(true);
+  expect(Number.isFinite(state.producedPowerWatts)).toBe(true);
+}
+
+function simulate(
+  powerWatts: number,
+  durationSeconds: number,
+  dtSeconds: number,
+  environment: FlatRoadEnvironment = referenceEnvironment,
+  checkInvariants = false,
+): SingleRiderState {
+  const state = createSingleRiderState(powerWatts);
+  const steps = Math.trunc(durationSeconds / dtSeconds);
+
+  for (let index = 0; index < steps; index += 1) {
+    const previousDistance = state.distanceMeters;
+    stepSingleRider(state, referenceProfile, environment, dtSeconds);
+
+    if (checkInvariants) {
+      expectFiniteState(state);
+      expect(state.speedMetersPerSecond).toBeGreaterThanOrEqual(0);
+      expect(state.distanceMeters).toBeGreaterThanOrEqual(previousDistance);
+    }
+  }
+
+  return state;
+}
+
+describe("single rider longitudinal physics", () => {
+  it("starts from rest without NaN or infinite values", () => {
+    const state = createSingleRiderState(250);
+
+    stepSingleRider(state, referenceProfile, referenceEnvironment, 0.5);
+
+    expectFiniteState(state);
+    expect(state.speedMetersPerSecond).toBeGreaterThan(0);
+    expect(state.distanceMeters).toBeGreaterThan(0);
+  });
+
+  it("keeps speed non-negative while coasting under resistance", () => {
+    const state = createSingleRiderState(0);
+    state.speedMetersPerSecond = 2;
+
+    for (let index = 0; index < 1_000; index += 1) {
+      stepSingleRider(state, referenceProfile, referenceEnvironment, 0.1);
+      expect(state.speedMetersPerSecond).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("keeps distance increasing when the rider moves forward", () => {
+    const state = simulate(200, 60, 0.5, referenceEnvironment, true);
+
+    expect(state.distanceMeters).toBeGreaterThan(0);
+  });
+
+  it("caps produced power at the rider maximum", () => {
+    const state = createSingleRiderState(2_000);
+
+    stepSingleRider(state, referenceProfile, referenceEnvironment, 0.5);
+
+    expect(state.producedPowerWatts).toBe(referenceProfile.maxPowerWatts);
+  });
+
+  it("stabilizes at a higher speed with 300 W than with 200 W", () => {
+    const speed200 = simulate(200, 7_200, 0.5).speedMetersPerSecond;
+    const speed300 = simulate(300, 7_200, 0.5).speedMetersPerSecond;
+
+    expect(speed300).toBeGreaterThan(speed200);
+  });
+
+  it("stabilizes slower with headwind than without wind", () => {
+    const noWind = simulate(250, 7_200, 0.5).speedMetersPerSecond;
+    const headwind = simulate(250, 7_200, 0.5, {
+      ...referenceEnvironment,
+      windSpeedMetersPerSecond: 3,
+    }).speedMetersPerSecond;
+
+    expect(headwind).toBeLessThan(noWind);
+  });
+
+  it("stabilizes faster with tailwind than without wind", () => {
+    const noWind = simulate(250, 7_200, 0.5).speedMetersPerSecond;
+    const tailwind = simulate(250, 7_200, 0.5, {
+      ...referenceEnvironment,
+      windSpeedMetersPerSecond: -3,
+    }).speedMetersPerSecond;
+
+    expect(tailwind).toBeGreaterThan(noWind);
+  });
+
+  it("decelerates without power under aerodynamic and rolling resistance", () => {
+    const state = createSingleRiderState(0);
+    state.speedMetersPerSecond = 10;
+
+    stepSingleRider(state, referenceProfile, referenceEnvironment, 1);
+
+    expect(state.speedMetersPerSecond).toBeLessThan(10);
+    expect(state.accelerationMetersPerSecondSquared).toBeLessThan(0);
+  });
+
+  it("is deterministic for identical inputs", () => {
+    const first = simulate(250, 3_600, 0.5, {
+      ...referenceEnvironment,
+      windSpeedMetersPerSecond: 1.5,
+    });
+    const second = simulate(250, 3_600, 0.5, {
+      ...referenceEnvironment,
+      windSpeedMetersPerSecond: 1.5,
+    });
+
+    expect(second).toStrictEqual(first);
+  });
+
+  it("keeps finite values during a long simulation", () => {
+    const state = simulate(250, 24 * 60 * 60, 1);
+
+    expectFiniteState(state);
+    expect(state.timeSeconds).toBe(86_400);
+  });
+});


### PR DESCRIPTION
### Motivation

- Fournir un moteur déterministe minimal calculant l'évolution de la vitesse et de la distance d'un coureur isolé sur route plate à partir de la puissance, du profil coureur‑vélo et des conditions d'environnement en unités SI.
- Respecter les contraintes du socle : pas de dépendance à React/Three.js/DOM, TypeScript strict, et tests Vitest inclus dans la même PR.

### Description

- Ajout de l'API publique dans `packages/sim-core/src/index.ts` exposant les types `SingleRiderProfile`, `FlatRoadEnvironment`, `SingleRiderState`, `SingleRiderForces`, et les fonctions `createSingleRiderState`, `computeSingleRiderForces`, `stepSingleRider` ; paramètres par défaut fournis.
- Calculs implémentés : masse totale, puissance produite bornée (`P = clamp(requested,0,Pmax)`), puissance mécanique effective, conversion puissance→force avec limite explicite de force propulsive basse vitesse (`F_prop = min(P_roue / max(v, P_roue / F_prop_max), F_prop_max)`), vitesse relative de l'air `v_air = v + v_wind`, traînée aérodynamique signée `0.5 * rho * CdA * v_air * |v_air|`, résistance au roulement appliquée si mouvement ou puissance, force nette, accélération et intégration explicite (Euler) de la vitesse et de la distance.
- Convention du vent : valeur positive = vent de face (headwind), valeur négative = vent arrière (tailwind); la vitesse relative de l'air est `v + v_wind`.
- Méthode basse vitesse : limite explicite de force propulsive (`maxPropulsiveForceNewtons`) évitant la division par zéro et assurant des accélérations finies au départ depuis l'arrêt.
- Fichiers modifiés : `packages/sim-core/src/index.ts`, `packages/sim-core/test/single-rider.test.ts`, `docs/SIMULATION_MODEL.md`, `docs/BENCHMARKS.md`, `docs/ARCHITECTURE.md`, `docs/PROJECT_STATUS.md`.
- Choix et hypothèses : unités SI strictes, intégration explicite par pas fourni `dt > 0`, état modifié en place pour éviter allocations par tick, pas de version bump nécessaire (package privé `0.0.0`).

### Testing

- Commandes exécutées : `pnpm install`, `pnpm install --frozen-lockfile`, `pnpm typecheck`, `pnpm test` ; la pipeline CI `Pull Request Checks` (inspectée) exécute `pnpm install --frozen-lockfile`, `pnpm typecheck` et `pnpm test` sur Node 24.
- Résultats automatisés : `tsc --noEmit` et l'ensemble des tests Vitest sont passés localement (`11 tests` verts, incluant tests de démarrage, invariants, plafonnement de puissance, effets du vent, décélération sans puissance, déterminisme et simulation longue).
- Scénario de référence et vitesses stabilisées (paramètres : coureur 75 kg, vélo 8 kg, CdA 0,32 m², Crr 0,004, rendement 0,97, Pmax 1 200 W, F_prop_max 1 200 N, rho 1,225 kg/m³, g 9,80665 m/s², durée 7 200 s, dt 0,5 s) :

  - 200 W sans vent : 9,411 m/s (33,88 km/h)
  - 250 W sans vent : 10,220 m/s (36,79 km/h)
  - 300 W sans vent : 10,923 m/s (39,32 km/h)
  - 250 W avec vent de face (+3 m/s) : 8,418 m/s (30,30 km/h)
  - 250 W avec vent arrière (-3 m/s) : 12,206 m/s (43,94 km/h)

- Remarques de test : assertions flottantes utilisent comparaisons relatives/invariants via tolérances raisonnables dans les tests (stabilité et déterminisme exact vérifiés), et aucun usage de `Math.random()` n'a été introduit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5350061ce48329b93d76e4b2e67d0b)