### PR TITLE
Atomicité du pas énergie/physique et forces explicites à la puissance produite

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Vue d'ensemble
 
-Le dépôt est organisé en workspace pnpm. Le socle contient les éléments nécessaires aux vérifications reproductibles et au noyau de simulation longitudinal minimal.
+Le dépôt est organisé en workspace pnpm. Le socle contient les éléments nécessaires aux vérifications reproductibles, au noyau de simulation longitudinal minimal et au modèle énergétique CP/W' minimal pour un coureur isolé.
 
 ## Packages
 
@@ -15,9 +15,15 @@ API exposée :
 - `SingleRiderProfile` décrit le couple coureur-vélo avec masses, CdA, coefficient de roulement, rendement mécanique, puissance maximale et limite de force propulsive basse vitesse.
 - `FlatRoadEnvironment` décrit l'air, le vent longitudinal et la gravité.
 - `SingleRiderState` contient l'état dynamique mutable.
-- `createSingleRiderState` crée un état initial typé.
-- `computeSingleRiderForces` calcule les forces longitudinales instantanées.
-- `stepSingleRider` valide les entrées publiques puis avance un état d'un pas temporel explicite.
+- `SingleRiderEnergyProfile` décrit les paramètres énergétiques CP/W' : puissance critique, capacité anaérobie et efficacité de récupération.
+- `SingleRiderEnergyState` contient la réserve anaérobie mutable, la puissance anaérobie appliquée, la récupération réellement stockée sur le dernier pas et l'indicateur de limitation énergétique.
+- `createSingleRiderState` crée un état physique initial typé.
+- `createSingleRiderEnergyState` crée un état énergétique initial typé avec une réserve pleine.
+- `computeSingleRiderForces` calcule les forces longitudinales instantanées avec `state.requestedPowerWatts`, bornée par la puissance maximale du profil. Cette fonction sert aux usages physiques historiques sans couplage énergétique.
+- `computeSingleRiderForcesAtPower` calcule les forces longitudinales instantanées avec une puissance explicitement fournie. Cette fonction sert aux consommateurs qui doivent analyser les forces correspondant à la puissance réellement produite, sans mutation temporaire de l'état.
+- `stepSingleRider` valide les entrées publiques puis avance un état physique d'un pas temporel explicite avec la puissance demandée.
+- `stepSingleRiderEnergy` valide les entrées publiques puis avance uniquement l'état énergétique à partir de la puissance demandée.
+- `stepSingleRiderWithEnergy` valide les entrées publiques, calcule un candidat énergétique et un candidat physique sans mutation, valide les résultats candidats, puis applique les deux états de façon atomique.
 
 Contraintes :
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -2,7 +2,7 @@
 
 ## Phase actuelle
 
-Roue libre est en phase de fondation technique, documentaire et physique minimale.
+Roue libre est en phase de fondation technique, documentaire, physique minimale et énergétique minimale.
 
 ## Existant
 
@@ -11,13 +11,15 @@ Roue libre est en phase de fondation technique, documentaire et physique minimal
 - Configuration Vitest via le package `sim-core`.
 - Package `packages/sim-core` sans dépendance graphique, navigateur, DOM, React ou Three.js.
 - Moteur longitudinal déterministe minimal pour un coureur isolé sur route plate.
+- Modèle énergétique minimal CP/W' pour un coureur isolé avec réserve anaérobie, limitation de puissance et récupération plafonnée.
+- Pas couplé énergie/physique atomique : les états physique et énergétique sont appliqués uniquement après validation complète des candidats.
 - Vérification CI pour l'installation, le typecheck et les tests sur Pull Request.
-- Documentation initiale du projet et du modèle physique longitudinal.
+- Documentation initiale du projet, du modèle physique longitudinal et du modèle énergétique minimal.
 
 ## Non existant
 
-Le projet ne contient pas de modèle d'énergie, puissance critique, fatigue, récupération, pente, GPX, virages, position latérale, aspiration, intelligence artificielle, rendu graphique, exécution Web Worker ou moteur de corps rigides.
+Le projet ne contient pas de pente, GPX, virages, position latérale, aspiration, intelligence artificielle, rendu graphique, exécution Web Worker ou moteur de corps rigides.
 
 ## Prochaine tâche unique
 
-Implémenter le modèle énergétique minimal du coureur isolé avec puissance critique, réserve anaérobie, consommation et récupération. Cette tâche n’est pas implémentée dans la PR du moteur longitudinal plat.
+Implémenter le laboratoire visuel minimal sans ajouter de fonctionnalité de simulation au-delà du modèle physique et énergétique existant.

--- a/docs/SIMULATION_MODEL.md
+++ b/docs/SIMULATION_MODEL.md
@@ -2,7 +2,7 @@
 
 ## Statut
 
-Le modèle implémenté couvre uniquement la physique longitudinale minimale d'un coureur isolé sur route plate. Il calcule l'évolution de la vitesse et de la distance à partir de la puissance demandée, du profil coureur-vélo, de l'environnement et d'un pas de temps explicite.
+Le modèle implémenté couvre la physique longitudinale minimale d'un coureur isolé sur route plate et un modèle énergétique CP/W' minimal. Il calcule l'évolution de la vitesse et de la distance à partir de la puissance, du profil coureur-vélo, de l'environnement et d'un pas de temps explicite. Le modèle énergétique limite la puissance produite lorsque la réserve anaérobie est insuffisante et récupère la réserve sous la puissance critique.
 
 ## Unités
 
@@ -14,6 +14,7 @@ Le moteur utilise les unités SI :
 - accélération : mètre par seconde carrée (`m/s²`) ;
 - masse : kilogramme (`kg`) ;
 - puissance : watt (`W`) ;
+- énergie : joule (`J`) ;
 - force : newton (`N`) ;
 - densité de l'air : kilogramme par mètre cube (`kg/m³`) ;
 - gravité : mètre par seconde carrée (`m/s²`) ;
@@ -21,7 +22,7 @@ Le moteur utilise les unités SI :
 
 ## Paramètres par défaut
 
-Les paramètres de référence exposés par `defaultSingleRiderProfile` et `defaultFlatRoadEnvironment` sont :
+Les paramètres de référence exposés par `defaultSingleRiderProfile`, `defaultSingleRiderEnergyProfile` et `defaultFlatRoadEnvironment` sont :
 
 | Paramètre | Valeur |
 | --- | ---: |
@@ -30,8 +31,11 @@ Les paramètres de référence exposés par `defaultSingleRiderProfile` et `defa
 | CdA | 0,32 m² |
 | Coefficient de résistance au roulement | 0,004 |
 | Rendement mécanique | 0,97 |
-| Puissance maximale | 1 200 W |
+| Puissance maximale physique | 1 200 W |
 | Force propulsive maximale | 200 N |
+| Puissance critique | 250 W |
+| Capacité anaérobie | 20 000 J |
+| Efficacité de récupération | 0,5 |
 | Densité de l'air | 1,225 kg/m³ |
 | Vent longitudinal | 0 m/s |
 | Gravité | 9,80665 m/s² |
@@ -52,7 +56,17 @@ v_air = v + v_vent
 
 avec `v` la vitesse du coureur et `v_vent` le vent longitudinal. Une vitesse relative positive produit une traînée opposée au déplacement. Une vitesse relative négative représente un vent arrière plus rapide que le coureur et produit une force aérodynamique signée dans le sens du déplacement.
 
-## Équations
+## Puissance demandée, produite et forces
+
+`SingleRiderState.requestedPowerWatts` représente la puissance demandée par le contrôle de simulation. `SingleRiderState.producedPowerWatts` représente la puissance effectivement appliquée par le dernier pas physique ou énergétique.
+
+`computeSingleRiderForces` utilise `state.requestedPowerWatts`, bornée dans `[0, profile.maxPowerWatts]`. Cette fonction décrit le comportement physique historique sans modèle énergétique.
+
+`computeSingleRiderForcesAtPower` utilise la puissance fournie explicitement en argument, bornée dans `[0, profile.maxPowerWatts]`. Cette fonction permet de calculer les forces correspondant à la puissance réellement produite par le modèle énergétique, sans modifier temporairement l'état et sans construire un faux état.
+
+`stepSingleRiderWithEnergy` calcule d'abord la puissance produite par le modèle énergétique, puis calcule les forces physiques avec cette puissance produite.
+
+## Équations physiques
 
 La masse totale est :
 
@@ -60,11 +74,13 @@ La masse totale est :
 m = m_coureur + m_velo
 ```
 
-La puissance effectivement produite est bornée :
+La puissance utilisée par le calcul de forces est bornée :
 
 ```text
-P = min(max(P_demandee, 0), P_max)
+P = min(max(P_source, 0), P_max)
 ```
+
+`P_source` vaut la puissance demandée pour `computeSingleRiderForces` et la puissance explicite pour `computeSingleRiderForcesAtPower`.
 
 La puissance à la roue tient compte du rendement mécanique :
 
@@ -101,6 +117,32 @@ F_net = F_prop - F_aero - F_rr
 a = F_net / m
 ```
 
+## Modèle énergétique CP/W'
+
+La puissance critique `CP` est la puissance durable minimale du modèle. La réserve anaérobie `W'` fournit la partie de la demande située au-dessus de `CP` tant que de l'énergie est disponible.
+
+Pour une demande au-dessus de `CP` :
+
+```text
+P_anaerobie_demandee = P_demandee - CP
+P_anaerobie_disponible = reserve / dt
+P_anaerobie = min(P_anaerobie_demandee, P_anaerobie_disponible)
+P_produite = CP + P_anaerobie
+reserve_suivante = reserve - P_anaerobie * dt
+```
+
+L'indicateur `isPowerLimitedByEnergy` vaut vrai lorsque la réserve disponible ne permet pas de fournir toute la puissance anaérobie demandée.
+
+Pour une demande sous `CP`, la réserve récupère selon l'efficacité configurée et reste plafonnée à la capacité :
+
+```text
+P_recuperation_potentielle = (CP - P_demandee) * efficacite
+reserve_suivante = min(capacite, reserve + P_recuperation_potentielle * dt)
+P_recuperation_appliquee = (reserve_suivante - reserve) / dt
+```
+
+`SingleRiderEnergyState.lastRecoveryPowerWatts` représente la récupération réellement stockée pendant le dernier pas, après plafonnement par la capacité. Une réserve presque pleine peut donc exposer une récupération appliquée inférieure à la récupération potentielle. Une capacité nulle expose une récupération appliquée nulle.
+
 ## Méthode d'intégration
 
 Chaque pas utilise un pas temporel explicite `dt` strictement positif. La vitesse suivante est calculée par Euler explicite puis bornée à zéro :
@@ -125,11 +167,13 @@ a_appliquee = (v_suivante - v) / dt
 
 Cette définition rend l'état cohérent avec l'évolution observée de la vitesse. Un coureur immobile qui reste à vitesse nulle après bornage expose donc une accélération appliquée nulle, même si la somme théorique des forces pointe vers l'arrière.
 
-## Validation des entrées
+## Atomicité et validation
 
-Les données publiques sont validées avant mutation de l'état. Les contraintes minimales sont : masse coureur strictement positive, masse vélo positive ou nulle, masse totale strictement positive, CdA positif ou nul, coefficient de roulement positif ou nul, rendement mécanique entre 0 et 1, puissance maximale positive ou nulle, force propulsive maximale strictement positive, densité de l'air positive ou nulle, gravité strictement positive, vent fini, état fini, temps, distance et vitesse non négatifs, puissance demandée finie et `dt` strictement positif.
+Les données publiques sont validées avant mutation de l'état. Les contraintes minimales sont : masse coureur strictement positive, masse vélo positive ou nulle, masse totale strictement positive, CdA positif ou nul, coefficient de roulement positif ou nul, rendement mécanique entre 0 et 1, puissance maximale positive ou nulle, force propulsive maximale strictement positive, densité de l'air positive ou nulle, gravité strictement positive, vent fini, état physique fini, temps, distance et vitesse non négatifs, puissance demandée finie, paramètres énergétiques non négatifs, réserve comprise entre zéro et capacité, efficacité de récupération entre 0 et 1 et `dt` strictement positif.
 
 Une entrée invalide lève une `RangeError` avec le nom du champ concerné avant toute mutation de l'état.
+
+Les forces calculées, les candidats physiques et les candidats énergétiques sont vérifiés comme finis avant commit. `stepSingleRiderWithEnergy` applique l'état physique et l'état énergétique uniquement après validation complète des deux candidats. Une erreur numérique pendant le calcul des forces ou des candidats laisse les deux états strictement inchangés.
 
 ## Invariants couverts par les tests
 
@@ -147,8 +191,12 @@ Les tests vérifient :
 - validation des entrées invalides sans mutation ;
 - vitesses stabilisées de référence avec tolérances explicites ;
 - accélération appliquée cohérente avec la vitesse bornée ;
-- valeurs finies sur simulation longue.
+- valeurs finies sur simulation longue ;
+- récupération réellement appliquée après plafonnement ;
+- atomicité du pas couplé énergie/physique en cas d'erreur numérique ;
+- forces explicites à la puissance réellement produite ;
+- transition de vitesse après épuisement de la réserve anaérobie.
 
 ## Simplifications et limites
 
-Le modèle ne couvre pas la pente, l'altitude, les virages, la position latérale, l'aspiration, la fatigue, la récupération, la réserve anaérobie, la puissance critique, les changements de posture, les pertes dépendantes de la transmission, le freinage, l'adhérence, les collisions, le GPX, l'intelligence artificielle, le rendu graphique ou l'exécution Web Worker.
+Le modèle ne couvre pas la pente, l'altitude, les virages, la position latérale, l'aspiration, les changements de posture, les pertes dépendantes de la transmission, le freinage, l'adhérence, les collisions, le GPX, l'intelligence artificielle, le rendu graphique ou l'exécution Web Worker.

--- a/packages/sim-core/src/index.ts
+++ b/packages/sim-core/src/index.ts
@@ -41,6 +41,21 @@ export interface SingleRiderState {
   producedPowerWatts: number;
 }
 
+/** Paramètres énergétiques CP/W' minimaux d'un coureur isolé, en unités SI. */
+export interface SingleRiderEnergyProfile {
+  criticalPowerWatts: number;
+  anaerobicCapacityJoules: number;
+  recoveryEfficiency: number;
+}
+
+/** État énergétique mutable d'un coureur isolé, en unités SI. */
+export interface SingleRiderEnergyState {
+  anaerobicReserveJoules: number;
+  anaerobicPowerWatts: number;
+  lastRecoveryPowerWatts: number;
+  isPowerLimitedByEnergy: boolean;
+}
+
 export interface SingleRiderForces {
   totalMassKg: number;
   producedPowerWatts: number;
@@ -50,6 +65,16 @@ export interface SingleRiderForces {
   rollingResistanceForceNewtons: number;
   netForceNewtons: number;
   accelerationMetersPerSecondSquared: number;
+}
+
+interface SingleRiderStepCandidate extends SingleRiderState {}
+
+interface SingleRiderEnergyStepResult {
+  producedPowerWatts: number;
+  nextAnaerobicReserveJoules: number;
+  anaerobicPowerWatts: number;
+  recoveryPowerWatts: number;
+  isPowerLimitedByEnergy: boolean;
 }
 
 export const defaultSingleRiderProfile: SingleRiderProfile = {
@@ -62,6 +87,12 @@ export const defaultSingleRiderProfile: SingleRiderProfile = {
   maxPropulsiveForceNewtons: 200,
 };
 
+export const defaultSingleRiderEnergyProfile: SingleRiderEnergyProfile = {
+  criticalPowerWatts: 250,
+  anaerobicCapacityJoules: 20_000,
+  recoveryEfficiency: 0.5,
+};
+
 export const defaultFlatRoadEnvironment: FlatRoadEnvironment = {
   airDensityKgPerCubicMeter: 1.225,
   windSpeedMetersPerSecond: 0,
@@ -71,6 +102,12 @@ export const defaultFlatRoadEnvironment: FlatRoadEnvironment = {
 function assertFinite(name: string, value: number): void {
   if (!Number.isFinite(value)) {
     throw new RangeError(`${name} must be finite`);
+  }
+}
+
+function assertFiniteResult(name: string, value: number): void {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`${name} result must be finite`);
   }
 }
 
@@ -102,6 +139,15 @@ function validateProfile(profile: SingleRiderProfile): void {
   assertPositive("profile.maxPropulsiveForceNewtons", profile.maxPropulsiveForceNewtons);
 }
 
+function validateEnergyProfile(energyProfile: SingleRiderEnergyProfile): void {
+  assertNonNegative("energyProfile.criticalPowerWatts", energyProfile.criticalPowerWatts);
+  assertNonNegative("energyProfile.anaerobicCapacityJoules", energyProfile.anaerobicCapacityJoules);
+  assertFinite("energyProfile.recoveryEfficiency", energyProfile.recoveryEfficiency);
+  if (energyProfile.recoveryEfficiency < 0 || energyProfile.recoveryEfficiency > 1) {
+    throw new RangeError("energyProfile.recoveryEfficiency must be between 0 and 1");
+  }
+}
+
 function validateEnvironment(environment: FlatRoadEnvironment): void {
   assertNonNegative("environment.airDensityKgPerCubicMeter", environment.airDensityKgPerCubicMeter);
   assertFinite("environment.windSpeedMetersPerSecond", environment.windSpeedMetersPerSecond);
@@ -117,6 +163,15 @@ function validateState(state: SingleRiderState): void {
   assertNonNegative("state.producedPowerWatts", state.producedPowerWatts);
 }
 
+function validateEnergyState(energyState: SingleRiderEnergyState, energyProfile: SingleRiderEnergyProfile): void {
+  assertNonNegative("energyState.anaerobicReserveJoules", energyState.anaerobicReserveJoules);
+  if (energyState.anaerobicReserveJoules > energyProfile.anaerobicCapacityJoules) {
+    throw new RangeError("energyState.anaerobicReserveJoules must be less than or equal to energyProfile.anaerobicCapacityJoules");
+  }
+  assertNonNegative("energyState.anaerobicPowerWatts", energyState.anaerobicPowerWatts);
+  assertNonNegative("energyState.lastRecoveryPowerWatts", energyState.lastRecoveryPowerWatts);
+}
+
 function validateStepInputs(
   state: SingleRiderState,
   profile: SingleRiderProfile,
@@ -127,6 +182,64 @@ function validateStepInputs(
   validateProfile(profile);
   validateEnvironment(environment);
   assertPositive("dtSeconds", dtSeconds);
+}
+
+function validateCombinedStepInputs(
+  state: SingleRiderState,
+  energyState: SingleRiderEnergyState,
+  profile: SingleRiderProfile,
+  energyProfile: SingleRiderEnergyProfile,
+  environment: FlatRoadEnvironment,
+  dtSeconds: number,
+): void {
+  validateStepInputs(state, profile, environment, dtSeconds);
+  validateEnergyProfile(energyProfile);
+  validateEnergyState(energyState, energyProfile);
+}
+
+function validateForces(forces: SingleRiderForces): void {
+  assertFiniteResult("forces.totalMassKg", forces.totalMassKg);
+  assertFiniteResult("forces.producedPowerWatts", forces.producedPowerWatts);
+  assertFiniteResult("forces.propulsiveForceNewtons", forces.propulsiveForceNewtons);
+  assertFiniteResult("forces.relativeAirSpeedMetersPerSecond", forces.relativeAirSpeedMetersPerSecond);
+  assertFiniteResult("forces.aerodynamicDragForceNewtons", forces.aerodynamicDragForceNewtons);
+  assertFiniteResult("forces.rollingResistanceForceNewtons", forces.rollingResistanceForceNewtons);
+  assertFiniteResult("forces.netForceNewtons", forces.netForceNewtons);
+  assertFiniteResult("forces.accelerationMetersPerSecondSquared", forces.accelerationMetersPerSecondSquared);
+}
+
+function validateStateCandidate(candidate: SingleRiderStepCandidate): void {
+  assertNonNegative("candidate.timeSeconds", candidate.timeSeconds);
+  assertNonNegative("candidate.distanceMeters", candidate.distanceMeters);
+  assertNonNegative("candidate.speedMetersPerSecond", candidate.speedMetersPerSecond);
+  assertFiniteResult("candidate.accelerationMetersPerSecondSquared", candidate.accelerationMetersPerSecondSquared);
+  assertFinite("candidate.requestedPowerWatts", candidate.requestedPowerWatts);
+  assertNonNegative("candidate.producedPowerWatts", candidate.producedPowerWatts);
+}
+
+function validateEnergyStepResult(
+  result: SingleRiderEnergyStepResult,
+  energyProfile: SingleRiderEnergyProfile,
+): void {
+  assertFiniteResult("energy.producedPowerWatts", result.producedPowerWatts);
+  assertFiniteResult("energy.nextAnaerobicReserveJoules", result.nextAnaerobicReserveJoules);
+  assertFiniteResult("energy.anaerobicPowerWatts", result.anaerobicPowerWatts);
+  assertFiniteResult("energy.recoveryPowerWatts", result.recoveryPowerWatts);
+  if (result.producedPowerWatts < 0) {
+    throw new RangeError("energy.producedPowerWatts result must be greater than or equal to zero");
+  }
+  if (result.nextAnaerobicReserveJoules < 0) {
+    throw new RangeError("energy.nextAnaerobicReserveJoules result must be greater than or equal to zero");
+  }
+  if (result.nextAnaerobicReserveJoules > energyProfile.anaerobicCapacityJoules) {
+    throw new RangeError("energy.nextAnaerobicReserveJoules result must be less than or equal to capacity");
+  }
+  if (result.anaerobicPowerWatts < 0) {
+    throw new RangeError("energy.anaerobicPowerWatts result must be greater than or equal to zero");
+  }
+  if (result.recoveryPowerWatts < 0) {
+    throw new RangeError("energy.recoveryPowerWatts result must be greater than or equal to zero");
+  }
 }
 
 function clamp(value: number, minimum: number, maximum: number): number {
@@ -146,19 +259,47 @@ export function createSingleRiderState(requestedPowerWatts: number): SingleRider
   };
 }
 
+export function createSingleRiderEnergyState(
+  energyProfile: SingleRiderEnergyProfile = defaultSingleRiderEnergyProfile,
+): SingleRiderEnergyState {
+  validateEnergyProfile(energyProfile);
+
+  return {
+    anaerobicReserveJoules: energyProfile.anaerobicCapacityJoules,
+    anaerobicPowerWatts: 0,
+    lastRecoveryPowerWatts: 0,
+    isPowerLimitedByEnergy: false,
+  };
+}
+
+/**
+ * Calcule les forces avec la puissance demandée de l'état, bornée par la puissance maximale du profil.
+ * Pour une simulation couplée à l'énergie, utiliser `computeSingleRiderForcesAtPower` avec la puissance produite.
+ */
 export function computeSingleRiderForces(
   state: SingleRiderState,
   profile: SingleRiderProfile,
   environment: FlatRoadEnvironment,
 ): SingleRiderForces {
+  return computeSingleRiderForcesAtPower(state, profile, environment, state.requestedPowerWatts);
+}
+
+/** Calcule les forces avec une puissance explicitement fournie, sans modifier l'état. */
+export function computeSingleRiderForcesAtPower(
+  state: SingleRiderState,
+  profile: SingleRiderProfile,
+  environment: FlatRoadEnvironment,
+  producedPowerWatts: number,
+): SingleRiderForces {
   validateState(state);
   validateProfile(profile);
   validateEnvironment(environment);
+  assertFinite("producedPowerWatts", producedPowerWatts);
 
   const totalMassKg = profile.riderMassKg + profile.bikeMassKg;
-  const producedPowerWatts = clamp(state.requestedPowerWatts, 0, profile.maxPowerWatts);
+  const boundedProducedPowerWatts = clamp(producedPowerWatts, 0, profile.maxPowerWatts);
   const maxPropulsiveForceNewtons = profile.maxPropulsiveForceNewtons;
-  const effectivePowerWatts = producedPowerWatts * profile.mechanicalEfficiency;
+  const effectivePowerWatts = boundedProducedPowerWatts * profile.mechanicalEfficiency;
   const forceFromPowerNewtons = effectivePowerWatts > 0
     ? effectivePowerWatts / Math.max(state.speedMetersPerSecond, effectivePowerWatts / maxPropulsiveForceNewtons)
     : 0;
@@ -176,9 +317,9 @@ export function computeSingleRiderForces(
   const netForceNewtons = propulsiveForceNewtons - aerodynamicDragForceNewtons - rollingResistanceForceNewtons;
   const accelerationMetersPerSecondSquared = netForceNewtons / totalMassKg;
 
-  return {
+  const forces = {
     totalMassKg,
-    producedPowerWatts,
+    producedPowerWatts: boundedProducedPowerWatts,
     propulsiveForceNewtons,
     relativeAirSpeedMetersPerSecond,
     aerodynamicDragForceNewtons,
@@ -186,6 +327,116 @@ export function computeSingleRiderForces(
     netForceNewtons,
     accelerationMetersPerSecondSquared,
   };
+  validateForces(forces);
+  return forces;
+}
+
+function computeSingleRiderStepCandidate(
+  state: SingleRiderState,
+  forces: SingleRiderForces,
+  dtSeconds: number,
+): SingleRiderStepCandidate {
+  const previousSpeedMetersPerSecond = Math.max(0, state.speedMetersPerSecond);
+  const nextSpeedMetersPerSecond = Math.max(
+    0,
+    previousSpeedMetersPerSecond + forces.accelerationMetersPerSecondSquared * dtSeconds,
+  );
+
+  const candidate = {
+    timeSeconds: state.timeSeconds + dtSeconds,
+    distanceMeters: state.distanceMeters + ((previousSpeedMetersPerSecond + nextSpeedMetersPerSecond) / 2) * dtSeconds,
+    speedMetersPerSecond: nextSpeedMetersPerSecond,
+    accelerationMetersPerSecondSquared: (nextSpeedMetersPerSecond - previousSpeedMetersPerSecond) / dtSeconds,
+    requestedPowerWatts: state.requestedPowerWatts,
+    producedPowerWatts: forces.producedPowerWatts,
+  };
+  validateStateCandidate(candidate);
+  return candidate;
+}
+
+function commitSingleRiderStep(state: SingleRiderState, candidate: SingleRiderStepCandidate): void {
+  state.timeSeconds = candidate.timeSeconds;
+  state.distanceMeters = candidate.distanceMeters;
+  state.speedMetersPerSecond = candidate.speedMetersPerSecond;
+  state.accelerationMetersPerSecondSquared = candidate.accelerationMetersPerSecondSquared;
+  state.producedPowerWatts = candidate.producedPowerWatts;
+}
+
+function computeSingleRiderEnergyStep(
+  requestedPowerWatts: number,
+  energyState: SingleRiderEnergyState,
+  energyProfile: SingleRiderEnergyProfile,
+  dtSeconds: number,
+): SingleRiderEnergyStepResult {
+  assertFinite("requestedPowerWatts", requestedPowerWatts);
+  validateEnergyProfile(energyProfile);
+  validateEnergyState(energyState, energyProfile);
+  assertPositive("dtSeconds", dtSeconds);
+
+  const requestedPositivePowerWatts = Math.max(0, requestedPowerWatts);
+  const requestedAnaerobicPowerWatts = Math.max(0, requestedPositivePowerWatts - energyProfile.criticalPowerWatts);
+  const availableAnaerobicPowerWatts = energyState.anaerobicReserveJoules / dtSeconds;
+  const anaerobicPowerWatts = Math.min(requestedAnaerobicPowerWatts, availableAnaerobicPowerWatts);
+  const isPowerLimitedByEnergy = anaerobicPowerWatts < requestedAnaerobicPowerWatts;
+  const producedPowerWatts = requestedPositivePowerWatts > energyProfile.criticalPowerWatts
+    ? energyProfile.criticalPowerWatts + anaerobicPowerWatts
+    : requestedPositivePowerWatts;
+
+  if (requestedPositivePowerWatts >= energyProfile.criticalPowerWatts) {
+    const nextAnaerobicReserveJoules = energyState.anaerobicReserveJoules - anaerobicPowerWatts * dtSeconds;
+    const result = {
+      producedPowerWatts,
+      nextAnaerobicReserveJoules,
+      anaerobicPowerWatts,
+      recoveryPowerWatts: 0,
+      isPowerLimitedByEnergy,
+    };
+    validateEnergyStepResult(result, energyProfile);
+    return result;
+  }
+
+  const potentialRecoveryPowerWatts = (energyProfile.criticalPowerWatts - requestedPositivePowerWatts)
+    * energyProfile.recoveryEfficiency;
+  const nextAnaerobicReserveJoules = Math.min(
+    energyProfile.anaerobicCapacityJoules,
+    energyState.anaerobicReserveJoules + potentialRecoveryPowerWatts * dtSeconds,
+  );
+  const recoveryPowerWatts = (nextAnaerobicReserveJoules - energyState.anaerobicReserveJoules) / dtSeconds;
+  const result = {
+    producedPowerWatts,
+    nextAnaerobicReserveJoules,
+    anaerobicPowerWatts: 0,
+    recoveryPowerWatts,
+    isPowerLimitedByEnergy: false,
+  };
+  validateEnergyStepResult(result, energyProfile);
+  return result;
+}
+
+function commitSingleRiderEnergyStep(
+  energyState: SingleRiderEnergyState,
+  result: SingleRiderEnergyStepResult,
+): void {
+  energyState.anaerobicReserveJoules = result.nextAnaerobicReserveJoules;
+  energyState.anaerobicPowerWatts = result.anaerobicPowerWatts;
+  energyState.lastRecoveryPowerWatts = result.recoveryPowerWatts;
+  energyState.isPowerLimitedByEnergy = result.isPowerLimitedByEnergy;
+}
+
+export function stepSingleRiderEnergy(
+  state: SingleRiderState,
+  energyState: SingleRiderEnergyState,
+  energyProfile: SingleRiderEnergyProfile,
+  dtSeconds: number,
+): void {
+  validateState(state);
+  validateEnergyProfile(energyProfile);
+  validateEnergyState(energyState, energyProfile);
+  assertPositive("dtSeconds", dtSeconds);
+
+  const result = computeSingleRiderEnergyStep(state.requestedPowerWatts, energyState, energyProfile, dtSeconds);
+  commitSingleRiderEnergyStep(energyState, result);
+  state.producedPowerWatts = result.producedPowerWatts;
 }
 
 export function stepSingleRider(
@@ -197,21 +448,27 @@ export function stepSingleRider(
   validateStepInputs(state, profile, environment, dtSeconds);
 
   const forces = computeSingleRiderForces(state, profile, environment);
-  const previousSpeedMetersPerSecond = Math.max(0, state.speedMetersPerSecond);
-  const nextSpeedMetersPerSecond = Math.max(
-    0,
-    previousSpeedMetersPerSecond + forces.accelerationMetersPerSecondSquared * dtSeconds,
-  );
+  const candidate = computeSingleRiderStepCandidate(state, forces, dtSeconds);
+  commitSingleRiderStep(state, candidate);
+}
 
-  state.timeSeconds += dtSeconds;
-  state.distanceMeters += ((previousSpeedMetersPerSecond + nextSpeedMetersPerSecond) / 2) * dtSeconds;
-  state.speedMetersPerSecond = nextSpeedMetersPerSecond;
-  state.accelerationMetersPerSecondSquared = (nextSpeedMetersPerSecond - previousSpeedMetersPerSecond) / dtSeconds;
-  state.producedPowerWatts = forces.producedPowerWatts;
+export function stepSingleRiderWithEnergy(
+  state: SingleRiderState,
+  energyState: SingleRiderEnergyState,
+  profile: SingleRiderProfile,
+  energyProfile: SingleRiderEnergyProfile,
+  environment: FlatRoadEnvironment,
+  dtSeconds: number,
+): void {
+  validateCombinedStepInputs(state, energyState, profile, energyProfile, environment, dtSeconds);
 
-  assertFinite("timeSeconds", state.timeSeconds);
-  assertFinite("distanceMeters", state.distanceMeters);
-  assertFinite("speedMetersPerSecond", state.speedMetersPerSecond);
-  assertFinite("accelerationMetersPerSecondSquared", state.accelerationMetersPerSecondSquared);
-  assertFinite("producedPowerWatts", state.producedPowerWatts);
+  const energyResult = computeSingleRiderEnergyStep(state.requestedPowerWatts, energyState, energyProfile, dtSeconds);
+  const forces = computeSingleRiderForcesAtPower(state, profile, environment, energyResult.producedPowerWatts);
+  const candidate = computeSingleRiderStepCandidate(state, forces, dtSeconds);
+
+  validateEnergyStepResult(energyResult, energyProfile);
+  validateStateCandidate(candidate);
+
+  commitSingleRiderEnergyStep(energyState, energyResult);
+  commitSingleRiderStep(state, candidate);
 }

--- a/packages/sim-core/test/single-rider.test.ts
+++ b/packages/sim-core/test/single-rider.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeSingleRiderForces,
+  computeSingleRiderForcesAtPower,
+  createSingleRiderEnergyState,
   createSingleRiderState,
   defaultFlatRoadEnvironment,
+  defaultSingleRiderEnergyProfile,
   defaultSingleRiderProfile,
   stepSingleRider,
+  stepSingleRiderEnergy,
+  stepSingleRiderWithEnergy,
   type FlatRoadEnvironment,
+  type SingleRiderEnergyProfile,
+  type SingleRiderEnergyState,
   type SingleRiderProfile,
   type SingleRiderState,
 } from "../src/index.js";
@@ -41,6 +49,10 @@ function expectFiniteState(state: SingleRiderState): void {
 }
 
 function cloneState(state: SingleRiderState): SingleRiderState {
+  return { ...state };
+}
+
+function cloneEnergyState(state: SingleRiderEnergyState): SingleRiderEnergyState {
   return { ...state };
 }
 
@@ -265,5 +277,172 @@ describe("single rider input validation", () => {
       stepSingleRider(state, referenceProfile, referenceEnvironment, 0.5);
     }).toThrow(/state\.distanceMeters/);
     expect(state).toStrictEqual(before);
+  });
+});
+
+describe("single rider energy model", () => {
+  const energyProfile: SingleRiderEnergyProfile = {
+    ...defaultSingleRiderEnergyProfile,
+    criticalPowerWatts: 250,
+    anaerobicCapacityJoules: 20_000,
+    recoveryEfficiency: 0.5,
+  };
+
+  it("stores only the recovery that fits below capacity", () => {
+    const state = createSingleRiderState(150);
+    const energyState = createSingleRiderEnergyState(energyProfile);
+    energyState.anaerobicReserveJoules = 19_990;
+
+    stepSingleRiderEnergy(state, energyState, energyProfile, 1);
+
+    expect(energyState.anaerobicReserveJoules).toBe(20_000);
+    expect(energyState.lastRecoveryPowerWatts).toBe(10);
+    expect(state.producedPowerWatts).toBe(150);
+  });
+
+  it("reports zero applied recovery when capacity is zero", () => {
+    const zeroCapacityProfile: SingleRiderEnergyProfile = {
+      criticalPowerWatts: 250,
+      anaerobicCapacityJoules: 0,
+      recoveryEfficiency: 0.5,
+    };
+    const state = createSingleRiderState(150);
+    const energyState = createSingleRiderEnergyState(zeroCapacityProfile);
+
+    stepSingleRiderEnergy(state, energyState, zeroCapacityProfile, 1);
+
+    expect(energyState.anaerobicReserveJoules).toBe(0);
+    expect(energyState.lastRecoveryPowerWatts).toBe(0);
+  });
+});
+
+describe("single rider energy and physics coupling", () => {
+  const energyProfile: SingleRiderEnergyProfile = {
+    ...defaultSingleRiderEnergyProfile,
+    criticalPowerWatts: 250,
+    anaerobicCapacityJoules: 20_000,
+    recoveryEfficiency: 0.5,
+  };
+
+  it("keeps both states unchanged when a finite time step overflows a candidate", () => {
+    const state = createSingleRiderState(350);
+    const energyState = createSingleRiderEnergyState(energyProfile);
+    const beforeState = cloneState(state);
+    const beforeEnergyState = cloneEnergyState(energyState);
+
+    expect(() => {
+      stepSingleRiderWithEnergy(
+        state,
+        energyState,
+        referenceProfile,
+        energyProfile,
+        referenceEnvironment,
+        Number.MAX_VALUE,
+      );
+    }).toThrow(
+      /candidate\.(timeSeconds|distanceMeters|speedMetersPerSecond|accelerationMetersPerSecondSquared).*finite/,
+    );
+    expect(state).toStrictEqual(beforeState);
+    expect(energyState).toStrictEqual(beforeEnergyState);
+  });
+
+  it("rejects non-finite calculated forces before any mutation", () => {
+    const state = createSingleRiderState(250);
+    state.speedMetersPerSecond = 1;
+    const energyState = createSingleRiderEnergyState(energyProfile);
+    const beforeState = cloneState(state);
+    const beforeEnergyState = cloneEnergyState(energyState);
+    const extremeEnvironment: FlatRoadEnvironment = {
+      ...referenceEnvironment,
+      windSpeedMetersPerSecond: Number.MAX_VALUE,
+    };
+
+    expect(() => computeSingleRiderForces(state, referenceProfile, extremeEnvironment)).toThrow(
+      /forces\.aerodynamicDragForceNewtons result must be finite/,
+    );
+    expect(() => {
+      stepSingleRiderWithEnergy(state, energyState, referenceProfile, energyProfile, extremeEnvironment, 1);
+    }).toThrow(/forces\.aerodynamicDragForceNewtons result must be finite/);
+    expect(state).toStrictEqual(beforeState);
+    expect(energyState).toStrictEqual(beforeEnergyState);
+  });
+
+  it("exposes forces for the produced power after energy limiting", () => {
+    const state = createSingleRiderState(350);
+    state.speedMetersPerSecond = 10;
+    const energyState = createSingleRiderEnergyState(energyProfile);
+    energyState.anaerobicReserveJoules = 0;
+
+    stepSingleRiderWithEnergy(state, energyState, referenceProfile, energyProfile, referenceEnvironment, 1);
+
+    const limitedForces = computeSingleRiderForcesAtPower(
+      state,
+      referenceProfile,
+      referenceEnvironment,
+      state.producedPowerWatts,
+    );
+    const physical250WState = { ...state, requestedPowerWatts: 250, producedPowerWatts: 0 };
+    const expectedForces = computeSingleRiderForces(physical250WState, referenceProfile, referenceEnvironment);
+    const requestedForces = computeSingleRiderForcesAtPower(state, referenceProfile, referenceEnvironment, 350);
+
+    expect(state.requestedPowerWatts).toBe(350);
+    expect(state.producedPowerWatts).toBe(250);
+    expect(limitedForces).toStrictEqual(expectedForces);
+    expect(limitedForces.propulsiveForceNewtons).not.toBeCloseTo(requestedForces.propulsiveForceNewtons, 12);
+  });
+
+  it("reduces speed progressively toward the critical-power behavior after reserve depletion", () => {
+    const state = createSingleRiderState(350);
+    const scenarioEnergyProfile = { ...energyProfile, anaerobicCapacityJoules: 20_000 };
+    const energyState = createSingleRiderEnergyState(scenarioEnergyProfile);
+    const cpState = createSingleRiderState(250);
+    const dtSeconds = 1;
+    let speedAtDepletion = 0;
+    let speedImmediatelyAfterDepletion = 0;
+    let observedAboveCriticalPower = false;
+
+    for (let index = 0; index < 240; index += 1) {
+      stepSingleRider(cpState, referenceProfile, referenceEnvironment, dtSeconds);
+      stepSingleRiderWithEnergy(
+        state,
+        energyState,
+        referenceProfile,
+        scenarioEnergyProfile,
+        referenceEnvironment,
+        dtSeconds,
+      );
+
+      expect(state.requestedPowerWatts).toBe(350);
+      if (!energyState.isPowerLimitedByEnergy) {
+        expect(state.producedPowerWatts).toBeGreaterThan(250);
+        observedAboveCriticalPower = true;
+      } else {
+        expect(state.producedPowerWatts).toBe(250);
+        speedAtDepletion = state.speedMetersPerSecond;
+        break;
+      }
+    }
+
+    expect(observedAboveCriticalPower).toBe(true);
+    expect(energyState.anaerobicReserveJoules).toBe(0);
+    speedImmediatelyAfterDepletion = state.speedMetersPerSecond;
+
+    for (let index = 0; index < 1_200; index += 1) {
+      stepSingleRider(cpState, referenceProfile, referenceEnvironment, dtSeconds);
+      stepSingleRiderWithEnergy(
+        state,
+        energyState,
+        referenceProfile,
+        scenarioEnergyProfile,
+        referenceEnvironment,
+        dtSeconds,
+      );
+      expect(state.requestedPowerWatts).toBe(350);
+      expect(state.producedPowerWatts).toBe(250);
+    }
+
+    expect(state.speedMetersPerSecond).toBeLessThan(speedAtDepletion);
+    expect(state.speedMetersPerSecond).toBeLessThan(speedImmediatelyAfterDepletion);
+    expect(Math.abs(state.speedMetersPerSecond - cpState.speedMetersPerSecond)).toBeLessThanOrEqual(0.05);
   });
 });


### PR DESCRIPTION
### Motivation
- Assurer l'application atomique des mises à jour physiques et énergétiques afin d'éviter des états partiellement modifiés en cas d'erreur numérique ou de dépassement.
- Rendre explicite la puissance utilisée pour calculer les forces afin que les consommateurs puissent obtenir les forces correspondant à la puissance réellement produite sans muter l'état.
- Rapport exact de la récupération appliquée après plafonnement de la capacité pour éviter une valeur trompeuse dans `lastRecoveryPowerWatts`.
- Couvrir ces comportements par des tests d'intégration et d'invariants pour préserver le déterminisme et les contraintes du socle.

### Description
- Refactorise le pas combiné en calculant d'abord un résultat énergétique pur via `computeSingleRiderEnergyStep` puis les forces via `computeSingleRiderForcesAtPower`, en validant les candidats avant de `commit`ter les états physiques et énergétiques.
- Introduit `SingleRiderEnergyProfile` et `SingleRiderEnergyState`, `createSingleRiderEnergyState`, ainsi qu'une structure interne `SingleRiderEnergyStepResult` pour centraliser le calcul énergétique sans mutation.
- Ajoute `computeSingleRiderForcesAtPower(state, profile, environment, producedPowerWatts)` qui calcule les forces à une puissance explicite, conserve `computeSingleRiderForces` comme wrapper sur la puissance demandée, et fait échouer si des valeurs non finies sont produites.
- Calcule et stocke `lastRecoveryPowerWatts` comme la récupération réellement appliquée après plafonnement de la capacité, et ajoute des validations supplémentaires (`validateForces`, `validateStateCandidate`, `validateEnergyStepResult`) pour garantir des résultats finis et conformes aux invariants.
- Réorganise `stepSingleRider`, découple génération de candidat et commit via `computeSingleRiderStepCandidate` et `commitSingleRiderStep`, et implémente `stepSingleRiderEnergy` et `stepSingleRiderWithEnergy` pour partager la logique pure énergétique.
- Ajoute des tests couvrant : récupération plafonnée et capacité nulle, atomicité en cas d'overflow numérique, rejet des forces non finies, exposition des forces correspondant à la puissance produite après limitation, et transition/convergence de la vitesse après épuisement de la réserve anaérobie.
- Met à jour `docs/ARCHITECTURE.md`, `docs/SIMULATION_MODEL.md` et `docs/PROJECT_STATUS.md` pour documenter les nouvelles API, la sémantique `requested` vs `produced` et l'atomicité du pas couplé.

### Testing
- Exécuté `pnpm install` (terminé avec l'avertissement d'environnement Node local), `pnpm typecheck` et `pnpm test` ; tous les tests TypeScript et Vitest sont passés avec succès.
- La suite de tests `packages/sim-core` s'exécute et retourne `33 passed, 0 failed` après les modifications.
- Vérifications additionnelles : `git diff --check` et validations locales de style/format n'ont révélé aucun problème.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53632caa088329bd7f362cb202b081)