### PR TITLE
feat(lab): add single-rider visual laboratory (apps/lab)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Test
         run: pnpm test
+
+      - name: Production build
+        run: pnpm build

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Roue libre
 
-Roue libre est un projet de simulation cycliste en phase de fondation technique.
+Roue libre est un projet de simulation cycliste en phase de fondation technique, physique minimale, énergétique minimale et laboratoire visuel minimal pour un coureur isolé.
 
 ## État du projet
 
-Le dépôt contient le socle minimal pour développer, tester et examiner les futures Pull Requests de manière reproductible. Aucune fonctionnalité de simulation cycliste n'est implémentée, validée ou exposée.
+Le dépôt contient un moteur longitudinal déterministe plat pour un coureur isolé, un modèle énergétique minimal CP/W' et une application web de laboratoire destinée à observer ces modèles. Le laboratoire expose les modèles implémentés et testés ; il ne valide pas de fonctionnalité hors périmètre comme la pente, le GPX, les virages, l'aspiration ou plusieurs coureurs.
 
 Consultez [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) avant toute modification importante.
 
@@ -13,24 +13,42 @@ Consultez [`docs/PROJECT_STATUS.md`](docs/PROJECT_STATUS.md) avant toute modific
 - Node.js 24 (`>=24 <25`)
 - pnpm 10.28.1
 
+## Installation
+
+```bash
+pnpm install
+```
+
 ## Workspace
 
 Le dépôt utilise un workspace pnpm avec TypeScript strict et Vitest.
 
 Packages présents :
 
-- `packages/sim-core` : package de base destiné au futur moteur de simulation. Il ne dépend pas de React, Three.js, du DOM, du navigateur ou d'une technologie graphique.
+- `packages/sim-core` : moteur de simulation longitudinal et énergétique minimal, sans dépendance à React, Vite, Three.js, au DOM, au navigateur ou à une technologie graphique.
+- `apps/lab` : laboratoire web Vite/React qui dépend de l'API publique de `@rouelibre/sim-core` pour piloter et observer un coureur isolé.
 
 ## Commandes
 
 ```bash
 pnpm install
+pnpm dev
 pnpm typecheck
 pnpm test
+pnpm build
 ```
 
-Le dépôt ne définit pas de script `build` racine parce qu'aucun build pertinent n'existe dans le socle actuel.
+- `pnpm dev` lance le laboratoire visuel.
+- `pnpm typecheck` vérifie le workspace en TypeScript strict.
+- `pnpm test` exécute les tests du moteur, du contrôleur du laboratoire, de l'adaptateur temporel et des composants React.
+- `pnpm build` produit le build de production du laboratoire.
+
+## Laboratoire visuel
+
+Le laboratoire permet de régler la puissance demandée de 0 à 1 200 W, le vent longitudinal de -10 à +10 m/s, de démarrer ou mettre en pause l'exécution, de réinitialiser le scénario et d'avancer exactement une seconde simulée lorsque l'exécution est en pause.
+
+Le pas de simulation est fixe (`1 / 60 s`). Le sélecteur ×1, ×5 ou ×20 change uniquement le nombre de ticks exécutés par seconde réelle. La réinitialisation remet le temps, la distance, la vitesse, l'accélération, la réserve W' et les observables du dernier pas à zéro ou à leur capacité maximale, tout en conservant la puissance et le vent sélectionnés pour répéter un scénario.
 
 ## Hors périmètre du socle actuel
 
-Le dépôt ne contient pas de moteur physique, d'énergie, d'intelligence artificielle, d'aspiration, de rendu graphique, d'import GPX, de Web Worker, de React, de Three.js, de Zustand ou de Rapier.
+Le dépôt ne contient pas de pente, altitude, GPX, virages, position latérale, aspiration, plusieurs coureurs, intelligence artificielle, tactique, psychologie, Three.js, scène 3D, Zustand, Web Worker, moteur de corps rigides, collisions, adhérence, sons, sauvegarde, backend, authentification ou déploiement.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pnpm build
 
 Le laboratoire permet de régler la puissance demandée de 0 à 1 200 W, le vent longitudinal de -10 à +10 m/s, de démarrer ou mettre en pause l'exécution, de réinitialiser le scénario et d'avancer exactement une seconde simulée lorsque l'exécution est en pause.
 
-Le pas de simulation est fixe (`1 / 60 s`). Le sélecteur ×1, ×5 ou ×20 change uniquement le nombre de ticks exécutés par seconde réelle. La réinitialisation remet le temps, la distance, la vitesse, l'accélération, la réserve W' et les observables du dernier pas à zéro ou à leur capacité maximale, tout en conservant la puissance et le vent sélectionnés pour répéter un scénario.
+Le pas de simulation est fixe (`1 / 60 s`). Le sélecteur ×1, ×5 ou ×20 change uniquement le nombre de ticks exécutés par seconde réelle : en fonctionnement normal, ×20 exécute vingt secondes simulées par seconde réelle sans modifier `dt`. Le plafond de sécurité concerne le temps réel rattrapable après une frame longue avant application du multiplicateur, afin d'éviter un rattrapage illimité après un gel ou un onglet inactif. La réinitialisation remet le temps, la distance, la vitesse, l'accélération, la réserve W' et les observables du dernier pas à zéro ou à leur capacité maximale, tout en conservant la puissance et le vent sélectionnés pour répéter un scénario.
 
 ## Hors périmètre du socle actuel
 

--- a/apps/lab/index.html
+++ b/apps/lab/index.html
@@ -1,0 +1,1 @@
+<!doctype html><html lang="fr"><head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>Roue libre — laboratoire</title></head><body><div id="root"></div><script type="module" src="/src/main.tsx"></script></body></html>

--- a/apps/lab/package.json
+++ b/apps/lab/package.json
@@ -11,14 +11,14 @@
   },
   "dependencies": {
     "@rouelibre/sim-core": "workspace:*",
-    "@vitejs/plugin-react": "^5.1.2",
-    "vite": "^7.3.6",
     "react": "^19.2.3",
     "react-dom": "^19.2.3"
   },
   "devDependencies": {
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
-    "jsdom": "^27.3.0"
+    "jsdom": "^27.3.0",
+    "vite": "^7.3.6",
+    "@vitejs/plugin-react": "^5.1.2"
   }
 }

--- a/apps/lab/package.json
+++ b/apps/lab/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@rouelibre/lab",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0",
+    "build": "tsc --noEmit -p tsconfig.json && vite build",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@rouelibre/sim-core": "workspace:*",
+    "@vitejs/plugin-react": "^5.1.2",
+    "vite": "^7.3.6",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "jsdom": "^27.3.0"
+  }
+}

--- a/apps/lab/src/App.test.tsx
+++ b/apps/lab/src/App.test.tsx
@@ -1,0 +1,27 @@
+// @vitest-environment jsdom
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, describe, expect, it } from "vitest";
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+import { App } from "./App.js";
+import { createLabSimulation, type LabSimulation } from "./simulation/labSimulation.js";
+
+let container: HTMLDivElement | undefined;
+function render(ui: React.ReactElement) {
+  container = document.createElement("div"); document.body.append(container); const root = createRoot(container); act(() => root.render(ui)); return { root, container };
+}
+afterEach(() => { if (container) { document.body.innerHTML = ""; container = undefined; } });
+const input = (name: string) => document.querySelector(`input[aria-label="${name}"]`) as HTMLInputElement;
+const click = (text: string) => act(() => { (Array.from(document.querySelectorAll("button")).find((b) => b.textContent === text) as HTMLButtonElement).click(); });
+const change = (el: HTMLInputElement, value: string) => act(() => { el.value = value; el.dispatchEvent(new Event("input", { bubbles: true })); el.dispatchEvent(new Event("change", { bubbles: true })); });
+
+describe("App", () => {
+  it("renders essential controls and observables", () => { render(<App />); expect(document.body.textContent).toContain("Puissance demandée"); expect(document.body.textContent).toContain("Vent longitudinal"); expect(document.body.textContent).toContain("État physique"); expect(document.body.textContent).toContain("Force nette"); });
+  it("changes requested power", () => { render(<App />); change(input("Puissance demandée"), "350"); expect(document.body.textContent).toContain("350 W"); });
+  it("changes wind", () => { render(<App />); change(input("Vent longitudinal"), "3"); expect(document.body.textContent).toContain("3.0 m/s"); });
+  it("starts and pauses", () => { render(<App />); click("Démarrer"); expect((Array.from(document.querySelectorAll("button")).find((b) => b.textContent === "Démarrer") as HTMLButtonElement).disabled).toBe(true); click("Pause"); expect((Array.from(document.querySelectorAll("button")).find((b) => b.textContent === "Démarrer") as HTMLButtonElement).disabled).toBe(false); });
+  it("advances manually by one second", () => { render(<App />); click("Avancer 1 s simulée"); expect(document.body.textContent).toContain("1.00 s"); });
+  it("resets after progression", () => { render(<App />); click("Avancer 1 s simulée"); click("Réinitialiser"); expect(document.body.textContent).toContain("0.00 s"); });
+  it("shows energy limitation status", () => { const sim = createLabSimulation(); sim.setRequestedPowerWatts(350); sim.stepTicks(12_001); render(<App simulation={sim} />); expect(document.body.textContent).toContain("Puissance limitée par l’énergie"); });
+  it("shows controlled engine error", () => { const broken: LabSimulation = { ...createLabSimulation(), stepTicks: () => { throw new RangeError("boom"); } }; render(<App simulation={broken} />); click("Avancer 1 s simulée"); expect(document.querySelector('[role="alert"]')?.textContent).toContain("boom"); });
+});

--- a/apps/lab/src/App.tsx
+++ b/apps/lab/src/App.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useMemo, useState } from "react";
+import { FixedStepRunner, type ObservationSpeed } from "./simulation/fixedStepRunner.js";
+import { createLabSimulation, type LabSimulation, type LabSimulationSnapshot } from "./simulation/labSimulation.js";
+
+const fmt = (value: number, digits = 2): string => value.toFixed(digits);
+
+interface AppProps { readonly simulation?: LabSimulation; }
+
+export function App({ simulation: providedSimulation }: AppProps): React.JSX.Element {
+  const simulation = useMemo(() => providedSimulation ?? createLabSimulation(), [providedSimulation]);
+  const [snapshot, setSnapshot] = useState<LabSimulationSnapshot>(() => simulation.getSnapshot());
+  const [running, setRunning] = useState(false);
+  const [error, setError] = useState<string | undefined>();
+  const [speed, setSpeed] = useState<ObservationSpeed>(1);
+  const runner = useMemo(() => new FixedStepRunner({ simulation, onAfterStep: () => setSnapshot(simulation.getSnapshot()), onError: (err) => { setRunning(false); setError(err instanceof Error ? err.message : String(err)); } }), [simulation]);
+  useEffect(() => () => runner.pause(), [runner]);
+  const refresh = (): void => setSnapshot(simulation.getSnapshot());
+  const setPower = (value: number): void => { simulation.setRequestedPowerWatts(value); refresh(); };
+  const setWind = (value: number): void => { simulation.setWindSpeedMetersPerSecond(value); refresh(); };
+  const start = (): void => { setError(undefined); runner.start(); setRunning(true); };
+  const pause = (): void => { runner.pause(); setRunning(false); };
+  const reset = (): void => { runner.pause(); simulation.reset(); setRunning(false); setError(undefined); refresh(); };
+  const manualStep = (): void => { try { runner.stepOneSimulatedSecond(); } catch (err) { setError(err instanceof Error ? err.message : String(err)); setRunning(false); } };
+  const setRunnerSpeed = (value: ObservationSpeed): void => { runner.setSpeed(value); setSpeed(value); };
+  const physical = snapshot.physicalState;
+  const energy = snapshot.energyState;
+  const forces = snapshot.forces;
+  const reservePercent = (energy.anaerobicReserveJoules / snapshot.energyProfile.anaerobicCapacityJoules) * 100;
+  const riderPercent = ((physical.distanceMeters % 100) / 100) * 100;
+
+  return <main className="app-shell">
+    <header><h1>Laboratoire visuel — coureur isolé</h1><p>Observation déterministe du moteur validé à pas fixe de {fmt(snapshot.tickSeconds, 4)} s.</p></header>
+    {error && <div role="alert" className="error">Erreur moteur : {error}</div>}
+    <section className="panel controls" aria-labelledby="controls-title"><h2 id="controls-title">Commandes</h2>
+      <label>Puissance demandée <input aria-label="Puissance demandée" type="range" min="0" max="1200" step="5" value={physical.requestedPowerWatts} onInput={(event) => setPower(event.currentTarget.valueAsNumber)} onChange={(event) => setPower(event.currentTarget.valueAsNumber)} /> <output>{fmt(physical.requestedPowerWatts, 0)} W</output></label>
+      <label>Vent longitudinal <input aria-label="Vent longitudinal" type="range" min="-10" max="10" step="0.5" value={snapshot.environment.windSpeedMetersPerSecond} onInput={(event) => setWind(event.currentTarget.valueAsNumber)} onChange={(event) => setWind(event.currentTarget.valueAsNumber)} /> <output>{fmt(snapshot.environment.windSpeedMetersPerSecond, 1)} m/s</output></label>
+      <p className="hint">Convention : valeur positive = vent de face ; valeur négative = vent arrière.</p>
+      <label>Vitesse d'observation <select aria-label="Vitesse d'observation" value={speed} onChange={(event) => setRunnerSpeed(Number(event.currentTarget.value) as ObservationSpeed)}><option value={1}>×1</option><option value={5}>×5</option><option value={20}>×20</option></select></label><strong>Multiplicateur actif : ×{speed}</strong>
+      <div className="buttons"><button type="button" onClick={start} disabled={running}>Démarrer</button><button type="button" onClick={pause} disabled={!running}>Pause</button><button type="button" onClick={reset}>Réinitialiser</button><button type="button" onClick={manualStep} disabled={running}>Avancer 1 s simulée</button></div>
+    </section>
+    <section className="panel visual" aria-labelledby="visual-title"><h2 id="visual-title">Route plate</h2><div className="road"><div className="rider" style={{ left: `${riderPercent}%` }} aria-label="Position visuelle du coureur" /></div><div className="gauge" aria-label="Jauge W prime"><span style={{ width: `${reservePercent}%` }} /></div><p>Réserve W′ : {fmt(energy.anaerobicReserveJoules, 0)} J ({fmt(reservePercent, 1)} %)</p></section>
+    <section className="grid" aria-label="Observables">
+      <article className="panel"><h2>État physique</h2><dl><dt>Temps simulé</dt><dd>{fmt(physical.timeSeconds)} s</dd><dt>Distance</dt><dd>{fmt(physical.distanceMeters)} m / {fmt(physical.distanceMeters / 1000, 3)} km</dd><dt>Vitesse</dt><dd>{fmt(physical.speedMetersPerSecond)} m/s / {fmt(physical.speedMetersPerSecond * 3.6)} km/h</dd><dt>Accélération</dt><dd>{fmt(physical.accelerationMetersPerSecondSquared)} m/s²</dd></dl></article>
+      <article className="panel"><h2>Puissance et énergie</h2><dl><dt>Puissance demandée</dt><dd>{fmt(physical.requestedPowerWatts, 0)} W</dd><dt>Puissance produite</dt><dd>{fmt(physical.producedPowerWatts, 0)} W</dd><dt>Puissance critique</dt><dd>{fmt(snapshot.energyProfile.criticalPowerWatts, 0)} W</dd><dt>Puissance anaérobie dernier pas</dt><dd>{fmt(energy.lastAnaerobicPowerWatts)} W</dd><dt>Puissance de récupération dernier pas</dt><dd>{fmt(energy.lastRecoveryPowerWatts)} W</dd><dt>Limitation énergétique</dt><dd>{energy.isPowerLimitedByEnergy ? "Puissance limitée par l’énergie" : "Aucune limitation énergétique"}</dd></dl></article>
+      <article className="panel"><h2>Environnement et forces</h2><dl><dt>Vitesse du vent</dt><dd>{fmt(snapshot.environment.windSpeedMetersPerSecond, 1)} m/s</dd><dt>Vitesse relative de l’air</dt><dd>{fmt(forces.relativeAirSpeedMetersPerSecond)} m/s</dd><dt>Force propulsive</dt><dd>{fmt(forces.propulsiveForceNewtons)} N</dd><dt>Traînée aérodynamique signée</dt><dd>{fmt(forces.aerodynamicDragForceNewtons)} N</dd><dt>Résistance au roulement</dt><dd>{fmt(forces.rollingResistanceForceNewtons)} N</dd><dt>Force nette</dt><dd>{fmt(forces.netForceNewtons)} N</dd></dl></article>
+    </section>
+  </main>;
+}

--- a/apps/lab/src/main.tsx
+++ b/apps/lab/src/main.tsx
@@ -1,0 +1,6 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+import "./styles.css";
+
+createRoot(document.getElementById("root")!).render(<StrictMode><App /></StrictMode>);

--- a/apps/lab/src/simulation/fixedStepRunner.test.ts
+++ b/apps/lab/src/simulation/fixedStepRunner.test.ts
@@ -1,26 +1,166 @@
 import { describe, expect, it, vi } from "vitest";
+import { LAB_TICK_SECONDS } from "./labSimulation.js";
 import { FixedStepRunner, type ObservationSpeed } from "./fixedStepRunner.js";
 
-function setup() {
+interface Harness {
+  readonly runner: FixedStepRunner;
+  readonly callbacks: FrameRequestCallback[];
+  setNow(value: number): void;
+  getTicks(): number;
+  getStepCalls(): readonly number[];
+  getAfterStepCalls(): number;
+  getErrorCalls(): number;
+}
+
+function setup(stepTicks?: (count: number) => void): Harness {
   let ticks = 0;
   let now = 0;
   const callbacks: FrameRequestCallback[] = [];
+  const stepCalls: number[] = [];
+  const onAfterStep = vi.fn();
+  const onError = vi.fn();
   const runner = new FixedStepRunner({
-    simulation: { stepTicks: (count) => { ticks += count; } },
-    onAfterStep: vi.fn(),
-    onError: vi.fn(),
+    simulation: {
+      stepTicks: (count) => {
+        stepCalls.push(count);
+        ticks += count;
+        stepTicks?.(count);
+      },
+    },
+    onAfterStep,
+    onError,
     now: () => now,
-    scheduleFrame: (cb) => { callbacks.push(cb); return callbacks.length; },
+    scheduleFrame: (callback) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    },
     cancelFrame: vi.fn(),
-    maxAccumulatedSeconds: 30,
   });
-  return { runner, callbacks, setNow: (value: number) => { now = value; }, getTicks: () => ticks };
+
+  return {
+    runner,
+    callbacks,
+    setNow: (value: number) => {
+      now = value;
+    },
+    getTicks: () => ticks,
+    getStepCalls: () => stepCalls,
+    getAfterStepCalls: () => onAfterStep.mock.calls.length,
+    getErrorCalls: () => onError.mock.calls.length,
+  };
+}
+
+function latestCallback(callbacks: readonly FrameRequestCallback[]): FrameRequestCallback {
+  const callback = callbacks.at(-1);
+  if (callback === undefined) {
+    throw new Error("expected a scheduled frame callback");
+  }
+  return callback;
+}
+
+function runFrames(harness: Harness, frameCount: number, frameDurationMilliseconds: number): void {
+  for (let index = 1; index <= frameCount; index += 1) {
+    latestCallback(harness.callbacks)(index * frameDurationMilliseconds);
+  }
 }
 
 describe("fixed step runner", () => {
-  it("does not execute ticks while paused", () => { const h = setup(); h.runner.tickForTests(1_000); expect(h.getTicks()).toBe(0); });
-  it("does not catch up a large inactive period on resume", () => { const h = setup(); h.setNow(0); h.runner.start(); h.runner.pause(); h.setNow(60_000); h.runner.start(); h.callbacks.at(-1)?.(60_000); expect(h.getTicks()).toBe(0); });
-  it.each([1, 5, 20] as ObservationSpeed[])("uses fixed dt at ×%s", (speed) => { const h = setup(); h.runner.setSpeed(speed); h.runner.start(); h.callbacks.at(-1)?.(1_000); expect(h.getTicks()).toBe(60 * speed); });
-  it("manual one-second step runs exactly 60 ticks", () => { const h = setup(); h.runner.stepOneSimulatedSecond(); expect(h.getTicks()).toBe(60); });
-  it("keeps fractional remainder between ordinary frames", () => { const h = setup(); h.runner.start(); h.callbacks.at(-1)?.(10); expect(h.getTicks()).toBe(0); h.callbacks.at(-1)?.(20); expect(h.getTicks()).toBe(1); });
+  it("does not execute ticks while paused", () => {
+    const harness = setup();
+
+    harness.runner.tickForTests(1_000);
+
+    expect(harness.getTicks()).toBe(0);
+  });
+
+  it("does not catch up a large inactive period on resume", () => {
+    const harness = setup();
+    harness.setNow(0);
+    harness.runner.start();
+    harness.runner.pause();
+    harness.setNow(60_000);
+    harness.runner.start();
+
+    latestCallback(harness.callbacks)(60_000);
+
+    expect(harness.getTicks()).toBe(0);
+  });
+
+  it.each([
+    [1, 60],
+    [5, 300],
+    [20, 1_200],
+  ] as const)("runs the expected ticks over one real second at ×%i", (speed: ObservationSpeed, expectedTicks) => {
+    const harness = setup();
+    harness.runner.setSpeed(speed);
+    harness.runner.start();
+
+    runFrames(harness, 60, 1_000 / 60);
+
+    expect(harness.getTicks()).toBe(expectedTicks);
+  });
+
+  it("runs about 20 ticks for an ordinary 60 Hz frame at ×20 instead of being capped to 15", () => {
+    const harness = setup();
+    harness.runner.setSpeed(20);
+    harness.runner.start();
+
+    latestCallback(harness.callbacks)(1_000 / 60);
+
+    expect(harness.getStepCalls()).toEqual([20]);
+  });
+
+  it("keeps the controller fixed step implicit by passing integer tick counts only", () => {
+    const harness = setup();
+    harness.runner.setSpeed(20);
+    harness.runner.start();
+
+    runFrames(harness, 60, 1_000 / 60);
+
+    expect(LAB_TICK_SECONDS).toBe(1 / 60);
+    expect(harness.getStepCalls().every((count) => Number.isInteger(count) && count > 0)).toBe(true);
+    expect(harness.getStepCalls().reduce((sum, count) => sum + count, 0)).toBe(1_200);
+  });
+
+  it("caps one very long inactive frame using the documented real-time catch-up policy", () => {
+    const harness = setup();
+    harness.runner.setSpeed(20);
+    harness.runner.start();
+
+    latestCallback(harness.callbacks)(60_000);
+
+    expect(harness.getStepCalls()).toEqual([300]);
+  });
+
+  it("manual one-second step runs exactly 60 ticks", () => {
+    const harness = setup();
+
+    harness.runner.stepOneSimulatedSecond();
+
+    expect(harness.getTicks()).toBe(60);
+  });
+
+  it("keeps fractional remainder between ordinary frames", () => {
+    const harness = setup();
+    harness.runner.start();
+
+    latestCallback(harness.callbacks)(10);
+    latestCallback(harness.callbacks)(20);
+
+    expect(harness.getStepCalls()).toEqual([1]);
+  });
+
+  it("pauses and reports an error when ticking fails", () => {
+    const harness = setup(() => {
+      throw new RangeError("boom");
+    });
+    harness.runner.start();
+
+    latestCallback(harness.callbacks)(1_000 / 60);
+    harness.runner.tickForTests(1_000);
+
+    expect(harness.getErrorCalls()).toBe(1);
+    expect(harness.getAfterStepCalls()).toBe(0);
+    expect(harness.getStepCalls()).toEqual([1]);
+  });
 });

--- a/apps/lab/src/simulation/fixedStepRunner.test.ts
+++ b/apps/lab/src/simulation/fixedStepRunner.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+import { FixedStepRunner, type ObservationSpeed } from "./fixedStepRunner.js";
+
+function setup() {
+  let ticks = 0;
+  let now = 0;
+  const callbacks: FrameRequestCallback[] = [];
+  const runner = new FixedStepRunner({
+    simulation: { stepTicks: (count) => { ticks += count; } },
+    onAfterStep: vi.fn(),
+    onError: vi.fn(),
+    now: () => now,
+    scheduleFrame: (cb) => { callbacks.push(cb); return callbacks.length; },
+    cancelFrame: vi.fn(),
+    maxAccumulatedSeconds: 30,
+  });
+  return { runner, callbacks, setNow: (value: number) => { now = value; }, getTicks: () => ticks };
+}
+
+describe("fixed step runner", () => {
+  it("does not execute ticks while paused", () => { const h = setup(); h.runner.tickForTests(1_000); expect(h.getTicks()).toBe(0); });
+  it("does not catch up a large inactive period on resume", () => { const h = setup(); h.setNow(0); h.runner.start(); h.runner.pause(); h.setNow(60_000); h.runner.start(); h.callbacks.at(-1)?.(60_000); expect(h.getTicks()).toBe(0); });
+  it.each([1, 5, 20] as ObservationSpeed[])("uses fixed dt at ×%s", (speed) => { const h = setup(); h.runner.setSpeed(speed); h.runner.start(); h.callbacks.at(-1)?.(1_000); expect(h.getTicks()).toBe(60 * speed); });
+  it("manual one-second step runs exactly 60 ticks", () => { const h = setup(); h.runner.stepOneSimulatedSecond(); expect(h.getTicks()).toBe(60); });
+  it("keeps fractional remainder between ordinary frames", () => { const h = setup(); h.runner.start(); h.callbacks.at(-1)?.(10); expect(h.getTicks()).toBe(0); h.callbacks.at(-1)?.(20); expect(h.getTicks()).toBe(1); });
+});

--- a/apps/lab/src/simulation/fixedStepRunner.ts
+++ b/apps/lab/src/simulation/fixedStepRunner.ts
@@ -1,0 +1,101 @@
+import { LAB_TICK_SECONDS, type LabSimulation } from "./labSimulation.js";
+
+export type ObservationSpeed = 1 | 5 | 20;
+export type AnimationScheduler = (callback: FrameRequestCallback) => number;
+export type AnimationCanceler = (handle: number) => void;
+export type NowProvider = () => number;
+
+interface FixedStepRunnerOptions {
+  readonly simulation: Pick<LabSimulation, "stepTicks">;
+  readonly onAfterStep: () => void;
+  readonly onError: (error: unknown) => void;
+  readonly now?: NowProvider;
+  readonly scheduleFrame?: AnimationScheduler;
+  readonly cancelFrame?: AnimationCanceler;
+  readonly maxAccumulatedSeconds?: number;
+}
+
+export class FixedStepRunner {
+  private readonly simulation: Pick<LabSimulation, "stepTicks">;
+  private readonly onAfterStep: () => void;
+  private readonly onError: (error: unknown) => void;
+  private readonly now: NowProvider;
+  private readonly scheduleFrame: AnimationScheduler;
+  private readonly cancelFrame: AnimationCanceler;
+  private readonly maxAccumulatedSeconds: number;
+  private frameHandle: number | undefined;
+  private running = false;
+  private lastTimestampSeconds: number | undefined;
+  private accumulatedSeconds = 0;
+  private speed: ObservationSpeed = 1;
+
+  constructor(options: FixedStepRunnerOptions) {
+    this.simulation = options.simulation;
+    this.onAfterStep = options.onAfterStep;
+    this.onError = options.onError;
+    this.now = options.now ?? (() => performance.now());
+    this.scheduleFrame = options.scheduleFrame ?? ((callback) => requestAnimationFrame(callback));
+    this.cancelFrame = options.cancelFrame ?? ((handle) => cancelAnimationFrame(handle));
+    this.maxAccumulatedSeconds = options.maxAccumulatedSeconds ?? 0.25;
+  }
+
+  start(): void {
+    if (this.running) return;
+    this.running = true;
+    this.lastTimestampSeconds = this.now() / 1_000;
+    this.frameHandle = this.scheduleFrame(this.handleFrame);
+  }
+
+  pause(): void {
+    this.running = false;
+    this.lastTimestampSeconds = undefined;
+    this.accumulatedSeconds = 0;
+    if (this.frameHandle !== undefined) {
+      this.cancelFrame(this.frameHandle);
+      this.frameHandle = undefined;
+    }
+  }
+
+  setSpeed(speed: ObservationSpeed): void {
+    this.speed = speed;
+  }
+
+  getSpeed(): ObservationSpeed {
+    return this.speed;
+  }
+
+  stepOneSimulatedSecond(): void {
+    this.simulation.stepTicks(60);
+    this.onAfterStep();
+  }
+
+  tickForTests(timestampMilliseconds: number): void {
+    this.handleFrame(timestampMilliseconds);
+  }
+
+  private readonly handleFrame = (timestampMilliseconds: number): void => {
+    if (!this.running) return;
+    try {
+      const timestampSeconds = timestampMilliseconds / 1_000;
+      if (this.lastTimestampSeconds === undefined) {
+        this.lastTimestampSeconds = timestampSeconds;
+      }
+      const elapsedSeconds = Math.max(0, timestampSeconds - this.lastTimestampSeconds);
+      this.lastTimestampSeconds = timestampSeconds;
+      this.accumulatedSeconds = Math.min(
+        this.maxAccumulatedSeconds,
+        this.accumulatedSeconds + elapsedSeconds * this.speed,
+      );
+      const tickCount = Math.floor(this.accumulatedSeconds / LAB_TICK_SECONDS);
+      if (tickCount > 0) {
+        this.accumulatedSeconds -= tickCount * LAB_TICK_SECONDS;
+        this.simulation.stepTicks(tickCount);
+        this.onAfterStep();
+      }
+      this.frameHandle = this.scheduleFrame(this.handleFrame);
+    } catch (error) {
+      this.pause();
+      this.onError(error);
+    }
+  };
+}

--- a/apps/lab/src/simulation/fixedStepRunner.ts
+++ b/apps/lab/src/simulation/fixedStepRunner.ts
@@ -12,8 +12,11 @@ interface FixedStepRunnerOptions {
   readonly now?: NowProvider;
   readonly scheduleFrame?: AnimationScheduler;
   readonly cancelFrame?: AnimationCanceler;
-  readonly maxAccumulatedSeconds?: number;
+  readonly maxRealFrameDeltaSeconds?: number;
 }
+
+const DEFAULT_MAX_REAL_FRAME_DELTA_SECONDS = 0.25;
+const TICK_EPSILON_SECONDS = LAB_TICK_SECONDS / 1_000_000;
 
 export class FixedStepRunner {
   private readonly simulation: Pick<LabSimulation, "stepTicks">;
@@ -22,11 +25,11 @@ export class FixedStepRunner {
   private readonly now: NowProvider;
   private readonly scheduleFrame: AnimationScheduler;
   private readonly cancelFrame: AnimationCanceler;
-  private readonly maxAccumulatedSeconds: number;
+  private readonly maxRealFrameDeltaSeconds: number;
   private frameHandle: number | undefined;
   private running = false;
   private lastTimestampSeconds: number | undefined;
-  private accumulatedSeconds = 0;
+  private accumulatedSimulationSeconds = 0;
   private speed: ObservationSpeed = 1;
 
   constructor(options: FixedStepRunnerOptions) {
@@ -36,7 +39,7 @@ export class FixedStepRunner {
     this.now = options.now ?? (() => performance.now());
     this.scheduleFrame = options.scheduleFrame ?? ((callback) => requestAnimationFrame(callback));
     this.cancelFrame = options.cancelFrame ?? ((handle) => cancelAnimationFrame(handle));
-    this.maxAccumulatedSeconds = options.maxAccumulatedSeconds ?? 0.25;
+    this.maxRealFrameDeltaSeconds = options.maxRealFrameDeltaSeconds ?? DEFAULT_MAX_REAL_FRAME_DELTA_SECONDS;
   }
 
   start(): void {
@@ -49,7 +52,7 @@ export class FixedStepRunner {
   pause(): void {
     this.running = false;
     this.lastTimestampSeconds = undefined;
-    this.accumulatedSeconds = 0;
+    this.accumulatedSimulationSeconds = 0;
     if (this.frameHandle !== undefined) {
       this.cancelFrame(this.frameHandle);
       this.frameHandle = undefined;
@@ -82,13 +85,14 @@ export class FixedStepRunner {
       }
       const elapsedSeconds = Math.max(0, timestampSeconds - this.lastTimestampSeconds);
       this.lastTimestampSeconds = timestampSeconds;
-      this.accumulatedSeconds = Math.min(
-        this.maxAccumulatedSeconds,
-        this.accumulatedSeconds + elapsedSeconds * this.speed,
-      );
-      const tickCount = Math.floor(this.accumulatedSeconds / LAB_TICK_SECONDS);
+      const cappedRealElapsedSeconds = Math.min(elapsedSeconds, this.maxRealFrameDeltaSeconds);
+      this.accumulatedSimulationSeconds += cappedRealElapsedSeconds * this.speed;
+      const tickCount = Math.floor((this.accumulatedSimulationSeconds + TICK_EPSILON_SECONDS) / LAB_TICK_SECONDS);
       if (tickCount > 0) {
-        this.accumulatedSeconds -= tickCount * LAB_TICK_SECONDS;
+        this.accumulatedSimulationSeconds = Math.max(
+          0,
+          this.accumulatedSimulationSeconds - tickCount * LAB_TICK_SECONDS,
+        );
         this.simulation.stepTicks(tickCount);
         this.onAfterStep();
       }

--- a/apps/lab/src/simulation/labSimulation.test.ts
+++ b/apps/lab/src/simulation/labSimulation.test.ts
@@ -1,0 +1,24 @@
+import { computeSingleRiderForcesAtPower, defaultSingleRiderProfile } from "@rouelibre/sim-core";
+import { describe, expect, it } from "vitest";
+import { createLabSimulation, LAB_ENERGY_PROFILE } from "./labSimulation.js";
+
+const closeTo = (a: number, b: number, d = 8) => expect(a).toBeCloseTo(b, d);
+const run = (power: number, wind: number, ticks: number) => { const s = createLabSimulation(); s.setRequestedPowerWatts(power); s.setWindSpeedMetersPerSecond(wind); s.stepTicks(ticks); return s.getSnapshot(); };
+
+describe("lab simulation controller", () => {
+  it("exposes the exact initial state", () => { const snap = createLabSimulation().getSnapshot(); expect(snap.physicalState).toMatchObject({ timeSeconds: 0, distanceMeters: 0, speedMetersPerSecond: 0, accelerationMetersPerSecondSquared: 0, requestedPowerWatts: 250, producedPowerWatts: 0 }); expect(snap.energyState).toMatchObject({ anaerobicReserveJoules: 20_000, lastAnaerobicPowerWatts: 0, lastRecoveryPowerWatts: 0, isPowerLimitedByEnergy: false }); expect(snap.environment.windSpeedMetersPerSecond).toBe(0); });
+  it("advances 600 ticks as about ten simulated seconds", () => closeTo(run(250, 0, 600).physicalState.timeSeconds, 10));
+  it("is deterministic for identical command and tick sequences", () => expect(run(350, 2, 1234)).toEqual(run(350, 2, 1234)));
+  it("has positive distance and speed after progression at 250 W", () => { const p = run(250, 0, 600).physicalState; expect(p.distanceMeters).toBeGreaterThan(0); expect(p.speedMetersPerSecond).toBeGreaterThan(0); });
+  it("keeps reserve unchanged at CP", () => closeTo(run(250, 0, 600).energyState.anaerobicReserveJoules, 20_000));
+  it("consumes reserve at 350 W", () => expect(run(350, 0, 600).energyState.anaerobicReserveJoules).toBeLessThan(20_000));
+  it("recovers below CP after prior consumption", () => { const s = createLabSimulation(); s.setRequestedPowerWatts(350); s.stepTicks(600); const depleted = s.getSnapshot().energyState.anaerobicReserveJoules; s.setRequestedPowerWatts(150); s.stepTicks(600); expect(s.getSnapshot().energyState.anaerobicReserveJoules).toBeGreaterThan(depleted); });
+  it("headwind reduces speed versus no wind", () => expect(run(250, 3, 1800).physicalState.speedMetersPerSecond).toBeLessThan(run(250, 0, 1800).physicalState.speedMetersPerSecond));
+  it("tailwind increases speed versus no wind", () => expect(run(250, -3, 1800).physicalState.speedMetersPerSecond).toBeGreaterThan(run(250, 0, 1800).physicalState.speedMetersPerSecond));
+  it("empty reserve limits a 350 W demand to 250 W", () => { const s = createLabSimulation(); s.setRequestedPowerWatts(350); s.stepTicks(12_001); closeTo(s.getSnapshot().physicalState.producedPowerWatts, 250); expect(s.getSnapshot().energyState.isPowerLimitedByEnergy).toBe(true); });
+  it("computes forces from produced power instead of requested power", () => { const snap = run(350, 0, 12_001); const producedForces = computeSingleRiderForcesAtPower(snap.physicalState, defaultSingleRiderProfile, snap.environment, snap.physicalState.producedPowerWatts); const requestedForces = computeSingleRiderForcesAtPower(snap.physicalState, defaultSingleRiderProfile, snap.environment, snap.physicalState.requestedPowerWatts); closeTo(snap.forces.propulsiveForceNewtons, producedForces.propulsiveForceNewtons); expect(snap.forces.propulsiveForceNewtons).not.toBeCloseTo(requestedForces.propulsiveForceNewtons, 4); });
+  it("resets physical and energy state", () => { const s = createLabSimulation(); s.setRequestedPowerWatts(350); s.stepTicks(600); s.reset(); const snap = s.getSnapshot(); expect(snap.physicalState.timeSeconds).toBe(0); expect(snap.physicalState.distanceMeters).toBe(0); expect(snap.physicalState.speedMetersPerSecond).toBe(0); expect(snap.energyState.anaerobicReserveJoules).toBe(LAB_ENERGY_PROFILE.anaerobicCapacityJoules); expect(snap.energyState.lastAnaerobicPowerWatts).toBe(0); });
+  it("keeps power and wind controls after reset", () => { const s = createLabSimulation(); s.setRequestedPowerWatts(500); s.setWindSpeedMetersPerSecond(-4); s.stepTicks(10); s.reset(); const snap = s.getSnapshot(); expect(snap.physicalState.requestedPowerWatts).toBe(500); expect(snap.environment.windSpeedMetersPerSecond).toBe(-4); });
+  it("rejects invalid tick counts", () => { const s = createLabSimulation(); expect(() => s.stepTicks(-1)).toThrow(RangeError); expect(() => s.stepTicks(1.5)).toThrow(RangeError); expect(() => s.stepTicks(Number.POSITIVE_INFINITY)).toThrow(RangeError); });
+  it("returns snapshots that cannot mutate internals", () => { const s = createLabSimulation(); const snap = s.getSnapshot(); expect(Object.isFrozen(snap.physicalState)).toBe(true); expect(() => { (snap.physicalState as { requestedPowerWatts: number }).requestedPowerWatts = 999; }).toThrow(TypeError); expect(s.getSnapshot().physicalState.requestedPowerWatts).toBe(250); });
+});

--- a/apps/lab/src/simulation/labSimulation.ts
+++ b/apps/lab/src/simulation/labSimulation.ts
@@ -1,0 +1,124 @@
+import {
+  computeSingleRiderForcesAtPower,
+  createSingleRiderEnergyState,
+  createSingleRiderState,
+  defaultFlatRoadEnvironment,
+  defaultSingleRiderProfile,
+  stepSingleRiderWithEnergy,
+  type FlatRoadEnvironment,
+  type SingleRiderEnergyProfile,
+  type SingleRiderEnergyState,
+  type SingleRiderForces,
+  type SingleRiderState,
+} from "@rouelibre/sim-core";
+
+export const LAB_TICK_SECONDS = 1 / 60;
+export const LAB_INITIAL_REQUESTED_POWER_WATTS = 250;
+export const LAB_ENERGY_PROFILE: Readonly<SingleRiderEnergyProfile> = Object.freeze({
+  criticalPowerWatts: 250,
+  anaerobicCapacityJoules: 20_000,
+  recoveryEfficiency: 0.5,
+});
+
+export interface LabSimulationSnapshot {
+  readonly physicalState: Readonly<SingleRiderState>;
+  readonly energyState: Readonly<SingleRiderEnergyState>;
+  readonly energyProfile: Readonly<SingleRiderEnergyProfile>;
+  readonly environment: Readonly<FlatRoadEnvironment>;
+  readonly forces: Readonly<SingleRiderForces>;
+  readonly tickSeconds: number;
+}
+
+export interface LabSimulation {
+  setRequestedPowerWatts(value: number): void;
+  setWindSpeedMetersPerSecond(value: number): void;
+  stepTicks(count: number): void;
+  reset(): void;
+  getSnapshot(): LabSimulationSnapshot;
+}
+
+function assertFiniteControl(name: string, value: number): void {
+  if (!Number.isFinite(value)) {
+    throw new RangeError(`${name} must be finite`);
+  }
+}
+
+function assertTickCount(count: number): void {
+  if (!Number.isFinite(count) || !Number.isInteger(count) || count < 0) {
+    throw new RangeError("tick count must be a non-negative finite integer");
+  }
+}
+
+function copyPhysicalState(state: SingleRiderState): SingleRiderState {
+  return { ...state };
+}
+
+function copyEnergyState(state: SingleRiderEnergyState): SingleRiderEnergyState {
+  return { ...state };
+}
+
+function copyEnvironment(environment: FlatRoadEnvironment): FlatRoadEnvironment {
+  return { ...environment };
+}
+
+function snapshotFrom(
+  physicalState: SingleRiderState,
+  energyState: SingleRiderEnergyState,
+  environment: FlatRoadEnvironment,
+): LabSimulationSnapshot {
+  const physicalStateCopy = copyPhysicalState(physicalState);
+  const energyStateCopy = copyEnergyState(energyState);
+  const environmentCopy = copyEnvironment(environment);
+  const forces = computeSingleRiderForcesAtPower(
+    physicalStateCopy,
+    defaultSingleRiderProfile,
+    environmentCopy,
+    physicalStateCopy.producedPowerWatts,
+  );
+  return Object.freeze({
+    physicalState: Object.freeze(physicalStateCopy),
+    energyState: Object.freeze(energyStateCopy),
+    energyProfile: LAB_ENERGY_PROFILE,
+    environment: Object.freeze(environmentCopy),
+    forces: Object.freeze({ ...forces }),
+    tickSeconds: LAB_TICK_SECONDS,
+  });
+}
+
+export function createLabSimulation(): LabSimulation {
+  let physicalState = createSingleRiderState(LAB_INITIAL_REQUESTED_POWER_WATTS);
+  let energyState = createSingleRiderEnergyState(LAB_ENERGY_PROFILE);
+  let environment: FlatRoadEnvironment = { ...defaultFlatRoadEnvironment };
+
+  return {
+    setRequestedPowerWatts(value: number): void {
+      assertFiniteControl("requestedPowerWatts", value);
+      physicalState.requestedPowerWatts = value;
+    },
+    setWindSpeedMetersPerSecond(value: number): void {
+      assertFiniteControl("windSpeedMetersPerSecond", value);
+      environment = { ...environment, windSpeedMetersPerSecond: value };
+    },
+    stepTicks(count: number): void {
+      assertTickCount(count);
+      for (let index = 0; index < count; index += 1) {
+        stepSingleRiderWithEnergy(
+          physicalState,
+          energyState,
+          defaultSingleRiderProfile,
+          LAB_ENERGY_PROFILE,
+          environment,
+          LAB_TICK_SECONDS,
+        );
+      }
+    },
+    reset(): void {
+      const requestedPowerWatts = physicalState.requestedPowerWatts;
+      physicalState = createSingleRiderState(requestedPowerWatts);
+      energyState = createSingleRiderEnergyState(LAB_ENERGY_PROFILE);
+    },
+    getSnapshot(): LabSimulationSnapshot {
+      return snapshotFrom(physicalState, energyState, environment);
+    },
+  };
+}

--- a/apps/lab/src/styles.css
+++ b/apps/lab/src/styles.css
@@ -1,0 +1,23 @@
+:root { color: #102018; background: #f4f7f3; font-family: system-ui, sans-serif; }
+body { margin: 0; }
+.app-shell { max-width: 1180px; margin: auto; padding: 1rem; }
+.panel { background: #fff; border: 1px solid #c9d4c7; border-radius: 12px; padding: 1rem; margin-block: 1rem; box-shadow: 0 1px 3px #0001; }
+.controls { display: grid; gap: .75rem; }
+label { display: grid; gap: .3rem; font-weight: 650; }
+input, select, button { font: inherit; }
+button { border: 1px solid #244b36; background: #244b36; color: white; border-radius: 8px; padding: .6rem .8rem; cursor: pointer; }
+button:disabled { opacity: .55; cursor: not-allowed; }
+.buttons { display: flex; flex-wrap: wrap; gap: .5rem; }
+.hint { margin: 0; color: #405447; }
+.error { border: 2px solid #8c1d18; background: #ffe9e7; padding: .8rem; border-radius: 8px; color: #5f110d; }
+.grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
+dl { display: grid; grid-template-columns: 1fr auto; gap: .45rem .8rem; }
+dt { color: #46584d; }
+dd { margin: 0; font-variant-numeric: tabular-nums; font-weight: 700; }
+.road { position: relative; height: 92px; border-bottom: 12px solid #424942; background: linear-gradient(#dfead8, #eff5ec); overflow: hidden; border-radius: 10px; }
+.rider { position: absolute; bottom: 12px; width: 34px; height: 24px; border-radius: 5px 12px 5px 5px; background: #1e5bb8; transform: translateX(-50%); }
+.rider::before, .rider::after { content: ""; position: absolute; bottom: -12px; width: 14px; height: 14px; border: 3px solid #111; border-radius: 50%; background: transparent; }
+.rider::before { left: -3px; } .rider::after { right: -3px; }
+.gauge { height: 24px; border: 1px solid #244b36; border-radius: 999px; overflow: hidden; background: #eef2ed; }
+.gauge span { display: block; height: 100%; background: #2d8a4e; }
+@media (max-width: 620px) { dl { grid-template-columns: 1fr; } .app-shell { padding: .75rem; } }

--- a/apps/lab/tsconfig.json
+++ b/apps/lab/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts"]
+}

--- a/apps/lab/vite.config.ts
+++ b/apps/lab/vite.config.ts
@@ -1,0 +1,9 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "node",
+  },
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,5 +46,30 @@ Contraintes :
 - `pnpm install` installe le workspace.
 - `pnpm typecheck` exécute le typecheck des packages.
 - `pnpm test` exécute les tests des packages.
+- `pnpm build` exécute le build de production des workspaces qui en définissent un, notamment le laboratoire visuel.
 
-Aucun script `build` racine n'est défini parce qu'aucun build pertinent n'existe.
+### `apps/lab`
+
+`apps/lab` contient le laboratoire visuel minimal du coureur isolé. L'application utilise Vite, React, TypeScript strict et du CSS simple. Elle dépend de `@rouelibre/sim-core` par son API publique et ne copie pas le moteur.
+
+Direction des dépendances :
+
+```text
+apps/lab → packages/sim-core
+```
+
+`sim-core` ne dépend pas du laboratoire, de React, de Vite, du DOM, du navigateur, de Three.js ni d'une bibliothèque graphique.
+
+Organisation :
+
+- `src/simulation/labSimulation.ts` contient le contrôleur indépendant de React et du DOM. Il possède les états physique et énergétique, applique CP = 250 W, W' = 20 000 J, une efficacité de récupération de 0,5, un pas fixe `1 / 60 s` et calcule les forces avec la puissance réellement produite.
+- `src/simulation/fixedStepRunner.ts` contient l'adaptateur temporel. Il transforme le temps réel issu de `requestAnimationFrame` en ticks entiers, conserve un reliquat, plafonne le rattrapage après gel et réinitialise sa référence temporelle lors d'une reprise.
+- `src/App.tsx` contient les composants React d'affichage et de commande. Les composants ne portent pas la logique de simulation et ne reçoivent que des instantanés copiés et gelés.
+- `src/styles.css` fournit une présentation CSS simple, responsive et lisible.
+
+Choix temporaires et réversibles :
+
+- Three.js est reporté parce qu'une route plate et un bloc cycliste suffisent à observer un seul coureur isolé.
+- Zustand est reporté parce qu'une page unique peut rester pilotée par l'état React local et un contrôleur explicite.
+- Web Worker est reporté parce qu'un seul coureur à 60 Hz ne justifie pas encore un protocole de messages dédié. La séparation entre contrôleur, adaptateur temporel et UI permet de déplacer ultérieurement l'exécution dans un Web Worker sans modifier `sim-core`.
+- Les bibliothèques de graphiques, de composants et les frameworks CSS sont reportés parce que les observables sont des valeurs numériques et des jauges simples.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -63,7 +63,7 @@ apps/lab → packages/sim-core
 Organisation :
 
 - `src/simulation/labSimulation.ts` contient le contrôleur indépendant de React et du DOM. Il possède les états physique et énergétique, applique CP = 250 W, W' = 20 000 J, une efficacité de récupération de 0,5, un pas fixe `1 / 60 s` et calcule les forces avec la puissance réellement produite.
-- `src/simulation/fixedStepRunner.ts` contient l'adaptateur temporel. Il transforme le temps réel issu de `requestAnimationFrame` en ticks entiers, conserve un reliquat, plafonne le rattrapage après gel et réinitialise sa référence temporelle lors d'une reprise.
+- `src/simulation/fixedStepRunner.ts` contient l'adaptateur temporel. Il transforme le temps réel issu de `requestAnimationFrame` en ticks entiers, conserve un reliquat, plafonne le temps réel rattrapable après une frame longue avant application du multiplicateur, puis réinitialise sa référence temporelle lors d'une reprise. Le multiplicateur ×20 produit vingt secondes simulées par seconde réelle en fonctionnement normal sans modifier le pas fixe `1 / 60 s`.
 - `src/App.tsx` contient les composants React d'affichage et de commande. Les composants ne portent pas la logique de simulation et ne reçoivent que des instantanés copiés et gelés.
 - `src/styles.css` fournit une présentation CSS simple, responsive et lisible.
 

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -18,7 +18,7 @@ Roue libre est en phase de fondation technique, documentaire, physique minimale,
 - Limitation de la puissance produite lorsque la réserve anaérobie ne permet pas de soutenir la demande.
 - Application `apps/lab` Vite/React permettant de piloter la puissance demandée, le vent longitudinal, l'exécution, la pause, la réinitialisation et l'avance manuelle d'une seconde simulée.
 - Contrôleur de laboratoire indépendant de React et du DOM, utilisant uniquement l'API publique de `@rouelibre/sim-core`.
-- Adaptateur temporel navigateur à pas fixe `1 / 60 s` avec accumulateur, multiplicateurs ×1, ×5 et ×20 et plafonnement du rattrapage après gel.
+- Adaptateur temporel navigateur à pas fixe `1 / 60 s` avec accumulateur, multiplicateurs ×1, ×5 et ×20, et plafonnement du temps réel rattrapable après une frame longue avant application du multiplicateur.
 - Affichage des observables physiques, énergétiques, environnementales et des forces du coureur isolé.
 - Représentation visuelle minimale dérivée de la distance simulée et jauge W'.
 - Vérification CI pour l'installation, le typecheck, les tests et le build sur Pull Request.

--- a/docs/PROJECT_STATUS.md
+++ b/docs/PROJECT_STATUS.md
@@ -2,13 +2,13 @@
 
 ## Phase actuelle
 
-Roue libre est en phase de fondation technique, documentaire, physique minimale et énergétique minimale pour un coureur isolé.
+Roue libre est en phase de fondation technique, documentaire, physique minimale, énergétique minimale et laboratoire visuel minimal pour un coureur isolé.
 
 ## Existant
 
 - Workspace pnpm minimal.
 - Configuration TypeScript stricte partagée.
-- Configuration Vitest via le package `sim-core`.
+- Configuration Vitest pour `sim-core` et le laboratoire.
 - Package `packages/sim-core` sans dépendance graphique, navigateur, DOM, React ou Three.js.
 - Moteur longitudinal déterministe minimal pour un coureur isolé sur route plate.
 - Distinction entre puissance demandée et puissance produite.
@@ -16,13 +16,22 @@ Roue libre est en phase de fondation technique, documentaire, physique minimale 
 - Modèle énergétique déterministe CP/W' pour un coureur isolé.
 - Consommation de la réserve anaérobie au-dessus de CP et récupération sous CP.
 - Limitation de la puissance produite lorsque la réserve anaérobie ne permet pas de soutenir la demande.
-- Vérification CI pour l'installation, le typecheck et les tests sur Pull Request.
-- Documentation du projet, du modèle physique longitudinal et du modèle énergétique minimal.
+- Application `apps/lab` Vite/React permettant de piloter la puissance demandée, le vent longitudinal, l'exécution, la pause, la réinitialisation et l'avance manuelle d'une seconde simulée.
+- Contrôleur de laboratoire indépendant de React et du DOM, utilisant uniquement l'API publique de `@rouelibre/sim-core`.
+- Adaptateur temporel navigateur à pas fixe `1 / 60 s` avec accumulateur, multiplicateurs ×1, ×5 et ×20 et plafonnement du rattrapage après gel.
+- Affichage des observables physiques, énergétiques, environnementales et des forces du coureur isolé.
+- Représentation visuelle minimale dérivée de la distance simulée et jauge W'.
+- Vérification CI pour l'installation, le typecheck, les tests et le build sur Pull Request.
+- Documentation du projet, de l'architecture, du modèle physique longitudinal, du modèle énergétique minimal et du laboratoire visuel.
+
+## Limites
+
+Le laboratoire observe le moteur existant et ne contient pas de nouvelle équation physique ou énergétique. La représentation visuelle est une aide d'observation dérivée de l'état simulé ; elle n'est pas une source de vérité. La réinitialisation conserve la puissance demandée et le vent pour faciliter la répétition d'un scénario.
 
 ## Non existant
 
-Le projet ne contient pas de pente, GPX, virages, position latérale, aspiration, intelligence artificielle, tactique, psychologie, rendu graphique, interface React, exécution Web Worker, moteur de corps rigides, collisions, adhérence, modèle physiologique complexe, courbes de puissance personnalisées, plusieurs réserves énergétiques, température, hydratation ou nutrition.
+Le projet ne contient pas de pente, GPX, virages, position latérale, aspiration, intelligence artificielle, tactique, psychologie, exécution Web Worker, moteur de corps rigides, collisions, adhérence, modèle physiologique complexe, courbes de puissance personnalisées, plusieurs réserves énergétiques, température, hydratation, nutrition, plusieurs coureurs, scène 3D, Three.js, Zustand, sons, sauvegarde, backend, authentification ou déploiement.
 
 ## Prochaine tâche unique
 
-Créer un laboratoire visuel minimal permettant de piloter la puissance et le vent et d'observer la vitesse, la distance, les forces, la puissance produite et la réserve énergétique.
+Ajouter une pente longitudinale constante au moteur physique, la documenter, la tester et l'exposer dans le laboratoire visuel, sans introduire encore de GPX ni de virages.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -7,11 +7,19 @@
 - Vitest.
 - CI Pull Request.
 - Documentation initiale.
+- Moteur déterministe minimal d'un coureur isolé sur route plate.
+- Modèle énergétique minimal CP/W'.
+
+## Phase laboratoire visuel
+
+- Le laboratoire minimal du coureur isolé fournit le pilotage de la puissance demandée, du vent longitudinal, de l'exécution, de la pause, de la réinitialisation et de l'avance manuelle d'une seconde simulée.
+- L'écran affiche les observables physiques, énergétiques, environnementales et les forces issues du moteur existant, avec une représentation visuelle simple dérivée de la distance et une jauge W'.
+- La phase ne contient pas de pente, GPX, virages, aspiration, plusieurs coureurs, Three.js, Zustand ni Web Worker.
 
 ## Prochaine tâche
 
-- Moteur déterministe minimal d'un coureur isolé sur route plate.
+- Ajouter une pente longitudinale constante au moteur physique, la documenter, la tester et l'exposer dans le laboratoire visuel, sans introduire encore de GPX ni de virages.
 
 ## Hors périmètre actuel
 
-Les sujets suivants ne font pas partie de la phase de fondation : React, Three.js, Zustand, Rapier, Web Worker, import GPX, physique cycliste complète, énergie, intelligence artificielle, aspiration et rendu graphique.
+Les sujets suivants ne font pas partie du périmètre implémenté : pente, altitude, GPX, virages, aspiration, plusieurs coureurs, intelligence artificielle, tactique, psychologie, scène 3D, Three.js, Zustand, Web Worker, Rapier, collisions, adhérence, sons, sauvegarde, backend, authentification et déploiement.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "install:workspace": "pnpm install",
     "typecheck": "pnpm -r typecheck",
-    "test": "pnpm -r test"
+    "test": "pnpm -r test",
+    "dev": "pnpm --filter @rouelibre/lab dev",
+    "build": "pnpm -r build"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,18 +20,12 @@ importers:
       '@rouelibre/sim-core':
         specifier: workspace:*
         version: link:../../packages/sim-core
-      '@vitejs/plugin-react':
-        specifier: ^5.1.2
-        version: 5.2.0(vite@7.3.6)
       react:
         specifier: ^19.2.3
         version: 19.2.7
       react-dom:
         specifier: ^19.2.3
         version: 19.2.7(react@19.2.7)
-      vite:
-        specifier: ^7.3.6
-        version: 7.3.6
     devDependencies:
       '@types/react':
         specifier: ^19.2.7
@@ -39,9 +33,15 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.2.0(vite@7.3.6)
       jsdom:
         specifier: ^27.3.0
         version: 27.4.0
+      vite:
+        specifier: ^7.3.6
+        version: 7.3.6
 
   packages/sim-core: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,170 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.7
+        version: 3.2.7(jsdom@27.4.0)
+
+  apps/lab:
+    dependencies:
+      '@rouelibre/sim-core':
+        specifier: workspace:*
+        version: link:../../packages/sim-core
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.2.0(vite@7.3.6)
+      react:
+        specifier: ^19.2.3
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.7(react@19.2.7)
+      vite:
+        specifier: ^7.3.6
+        version: 7.3.6
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      jsdom:
+        specifier: ^27.3.0
+        version: 27.4.0
 
   packages/sim-core: {}
 
 packages:
+
+  '@acemir/cssom@0.9.31':
+    resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@asamuzakjp/css-color@4.1.2':
+    resolution: {integrity: sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==}
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    resolution: {integrity: sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.2.1':
+    resolution: {integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.9':
+    resolution: {integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6':
+    resolution: {integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -175,8 +334,33 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -303,6 +487,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -311,6 +507,20 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
@@ -341,13 +551,33 @@ packages:
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001805:
+    resolution: {integrity: sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==}
 
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
@@ -356,6 +586,24 @@ packages:
   check-error@2.1.3:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  cssstyle@5.3.7:
+    resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
+    engines: {node: '>=20'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@6.0.1:
+    resolution: {integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==}
+    engines: {node: '>=20'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -366,9 +614,19 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+
+  electron-to-chromium@1.5.389:
+    resolution: {integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -377,6 +635,10 @@ packages:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -399,14 +661,65 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsdom@27.4.0:
+    resolution: {integrity: sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -415,6 +728,13 @@ packages:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
+
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -434,9 +754,41 @@ packages:
     resolution: {integrity: sha512-J7EF+8X+CzRPaJPOv9Ck2wNWJvGnnl3PcNPAdGg6GTLjyVpyQ0yATMSXRFRV01BviT/9Gwuc3rjEyJbDJG9a4w==}
     engines: {node: ^10 || ^12 || >=14}
 
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   siginfo@2.0.0:
@@ -454,6 +806,9 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -477,10 +832,31 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.4.8:
+    resolution: {integrity: sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==}
+
+  tldts@7.4.8:
+    resolution: {integrity: sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -555,12 +931,210 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@15.1.0:
+    resolution: {integrity: sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==}
+    engines: {node: '>=20'}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
 snapshots:
+
+  '@acemir/cssom@0.9.31': {}
+
+  '@asamuzakjp/css-color@4.1.2':
+    dependencies:
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@6.8.1':
+    dependencies:
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.6
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
@@ -640,7 +1214,28 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@exodus/bytes@1.15.1': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -717,6 +1312,27 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -725,6 +1341,26 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.6
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitest/expect@3.2.7':
     dependencies:
@@ -768,9 +1404,27 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  agent-base@7.1.4: {}
+
   assertion-error@2.0.1: {}
 
+  baseline-browser-mapping@2.10.43: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
+
+  browserslist@4.28.6:
+    dependencies:
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001805
+      electron-to-chromium: 1.5.389
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
+
   cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001805: {}
 
   chai@5.3.3:
     dependencies:
@@ -782,11 +1436,38 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  convert-source-map@2.0.0: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  cssstyle@5.3.7:
+    dependencies:
+      '@asamuzakjp/css-color': 4.1.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.6(css-tree@3.2.1)
+      css-tree: 3.2.1
+      lru-cache: 11.5.2
+
+  csstype@3.2.3: {}
+
+  data-urls@6.0.1:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 15.1.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-eql@5.0.2: {}
+
+  electron-to-chromium@1.5.389: {}
+
+  entities@8.0.0: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -819,6 +1500,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.1
       '@esbuild/win32-x64': 0.28.1
 
+  escalade@3.2.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -832,17 +1515,89 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  gensync@1.0.0-beta.2: {}
+
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  is-potential-custom-element-name@1.0.1: {}
+
+  js-tokens@4.0.0: {}
+
   js-tokens@9.0.1: {}
 
+  jsdom@27.4.0:
+    dependencies:
+      '@acemir/cssom': 0.9.31
+      '@asamuzakjp/dom-selector': 6.8.1
+      '@exodus/bytes': 1.15.1
+      cssstyle: 5.3.7
+      data-urls: 6.0.1
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 15.1.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
   loupe@3.2.1: {}
+
+  lru-cache@11.5.2: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
 
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  mdn-data@2.27.1: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.15: {}
+
+  node-releases@2.0.51: {}
+
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
 
   pathe@2.0.3: {}
 
@@ -857,6 +1612,19 @@ snapshots:
       nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  punycode@2.3.1: {}
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.7: {}
+
+  require-from-string@2.0.2: {}
 
   rollup@4.62.2:
     dependencies:
@@ -889,6 +1657,14 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -900,6 +1676,8 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  symbol-tree@3.2.4: {}
 
   tinybench@2.9.0: {}
 
@@ -916,7 +1694,27 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.4.8: {}
+
+  tldts@7.4.8:
+    dependencies:
+      tldts-core: 7.4.8
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.8
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
+
   typescript@5.9.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
+    dependencies:
+      browserslist: 4.28.6
+      escalade: 3.2.0
+      picocolors: 1.1.1
 
   vite-node@3.2.4:
     dependencies:
@@ -950,7 +1748,7 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@3.2.7:
+  vitest@3.2.7(jsdom@27.4.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -975,6 +1773,8 @@ snapshots:
       vite: 7.3.6
       vite-node: 3.2.4
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 27.4.0
     transitivePeerDependencies:
       - jiti
       - less
@@ -989,7 +1789,30 @@ snapshots:
       - tsx
       - yaml
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@15.1.0:
+    dependencies:
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  ws@8.21.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
+
+  yallist@3.1.1: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "apps/*"


### PR DESCRIPTION
### Motivation
- Fournir un laboratoire web minimal permettant d'observer et piloter le moteur longitudinal et énergétique existant pour un coureur isolé sans modifier `sim-core`.
- Exposer une UI simple pour régler la puissance et le vent, contrôler l'exécution (play/pause/reset/step) et visualiser en temps réel les observables physiques, énergétiques et les forces.
- Séparer la logique de simulation hors des composants React via un contrôleur indépendant et un adaptateur temporel navigateur à pas fixe pour garantir déterminisme et portabilité vers un Web Worker ultérieur.
- Documenter et intégrer le laboratoire dans le workspace sans introduire de nouvelles équations physiques ni bibliothèques graphiques lourdes (Three.js, Zustand, etc.).

### Description
- Ajout de l'application `apps/lab` (Vite + React + TypeScript strict) contenant `App.tsx`, `main.tsx`, `styles.css` et `index.html` pour l'interface utilitaire et la représentation visuelle minimale du coureur et de la route.
- Implémentation du contrôleur `src/simulation/labSimulation.ts` indépendant de React utilisant exclusivement l'API publique `@rouelibre/sim-core` avec CP = 250 W, W' = 20 000 J, récupération = 0,5 et pas fixe `dt = 1/60 s`, et fournissant des instantanés gelés en lecture seule.
- Ajout de l'adaptateur temporel `src/simulation/fixedStepRunner.ts` transformant `requestAnimationFrame` en ticks entiers, conservant un reliquat, plafonnant le rattrapage après gel et supportant les multiplicateurs ×1/×5/×20 sans modifier `dt`.
- Tests Vitest ajoutés pour le contrôleur (`labSimulation.test.ts`), l'adaptateur temporel (`fixedStepRunner.test.ts`) et l'UI React (`App.test.tsx`), mise à jour des scripts workspace (`pnpm dev`, `pnpm build`, `pnpm typecheck`, `pnpm test`), et inclusion d'`apps/*` dans le workspace.
- Documentation mise à jour : `README.md`, `docs/ARCHITECTURE.md`, `docs/PROJECT_STATUS.md`, `docs/ROADMAP.md`, et CI (`.github/workflows/pr-checks.yml`) étendu pour lancer le build de production.
- Aucune dépendance ajoutée à `packages/sim-core`; la direction des dépendances reste `apps/lab → packages/sim-core`, et les choix technologiques lourds (Three.js, Zustand, Web Worker, bibliothèques graphiques) sont explicitement reportés.

### Testing
- Exécuté `pnpm install` (localement avec un avertissement sur la version Node différente), et l'installation a réussi.
- Exécuté `pnpm typecheck` sur le workspace avec succès (TypeScript strict), et tous les projets passent le contrôle de types.
- Exécuté `pnpm test` pour `packages/sim-core` et `apps/lab`, tous les tests Vitest ajoutés et existants sont passés avec succès.
- Exécuté `pnpm build` pour l'application `apps/lab` et le build de production a été généré avec succès; la CI workflow a été mis à jour pour exécuter install/typecheck/test/build sur les PRs.

No version bump required: all packages are private workspace manifests and this change adds an application workspace without modifying published package APIs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a537103bc3c83299826c35a58a35f94)