### PR TITLE
chore: add preview deployment workflow

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,122 @@
+name: Deploy Preview Lab
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - preview
+
+concurrency:
+  group: preview-deployment
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Build and deploy preview lab
+    runs-on: ubuntu-latest
+    environment: preview
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Production build
+        run: pnpm build
+
+      - name: Verify lab build output
+        run: test -f apps/lab/dist/index.html
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: roue-libre-lab-preview
+          path: apps/lab/dist
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Validate preview deployment configuration
+        env:
+          PREVIEW_HOST: ${{ secrets.PREVIEW_HOST }}
+          PREVIEW_PORT: ${{ secrets.PREVIEW_PORT }}
+          PREVIEW_USER: ${{ secrets.PREVIEW_USER }}
+          PREVIEW_SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+          PREVIEW_PATH: ${{ secrets.PREVIEW_PATH }}
+        run: |
+          set -euo pipefail
+
+          missing=0
+          for name in PREVIEW_HOST PREVIEW_PORT PREVIEW_USER PREVIEW_SSH_KEY PREVIEW_PATH; do
+            if [ -z "${!name}" ]; then
+              echo "::error::Required preview secret ${name} is missing or empty."
+              missing=1
+            fi
+          done
+
+          if [ "${missing}" -ne 0 ]; then
+            exit 1
+          fi
+
+          if [ "${PREVIEW_PATH}" = "/" ]; then
+            echo "::error::PREVIEW_PATH must not be /. Refusing to run rsync --delete against the server root."
+            exit 1
+          fi
+
+          case "${PREVIEW_PATH}" in
+            /*) ;;
+            *)
+              echo "::error::PREVIEW_PATH must be a non-empty absolute path."
+              exit 1
+              ;;
+          esac
+
+      - name: Configure SSH
+        env:
+          PREVIEW_HOST: ${{ secrets.PREVIEW_HOST }}
+          PREVIEW_PORT: ${{ secrets.PREVIEW_PORT }}
+          PREVIEW_SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+        run: |
+          set -euo pipefail
+
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${PREVIEW_SSH_KEY}" > ~/.ssh/preview_deploy_key
+          chmod 600 ~/.ssh/preview_deploy_key
+          ssh-keyscan -p "${PREVIEW_PORT}" "${PREVIEW_HOST}" >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Deploy preview over SSH
+        env:
+          PREVIEW_HOST: ${{ secrets.PREVIEW_HOST }}
+          PREVIEW_PORT: ${{ secrets.PREVIEW_PORT }}
+          PREVIEW_USER: ${{ secrets.PREVIEW_USER }}
+          PREVIEW_PATH: ${{ secrets.PREVIEW_PATH }}
+        run: |
+          set -euo pipefail
+
+          remote_path=$(printf '%q' "${PREVIEW_PATH}")
+          ssh -i ~/.ssh/preview_deploy_key -p "${PREVIEW_PORT}" "${PREVIEW_USER}@${PREVIEW_HOST}" \
+            "mkdir -p -- ${remote_path}"
+
+          rsync -az --delete \
+            -e "ssh -i ~/.ssh/preview_deploy_key -p ${PREVIEW_PORT}" \
+            apps/lab/dist/ \
+            "${PREVIEW_USER}@${PREVIEW_HOST}:${PREVIEW_PATH}/"

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Le laboratoire permet de régler la puissance demandée de 0 à 1 200 W, le vent
 
 Le pas de simulation est fixe (`1 / 60 s`). Le sélecteur ×1, ×5 ou ×20 change uniquement le nombre de ticks exécutés par seconde réelle : en fonctionnement normal, ×20 exécute vingt secondes simulées par seconde réelle sans modifier `dt`. Le plafond de sécurité concerne le temps réel rattrapable après une frame longue avant application du multiplicateur, afin d'éviter un rattrapage illimité après un gel ou un onglet inactif. La réinitialisation remet le temps, la distance, la vitesse, l'accélération, la réserve W' et les observables du dernier pas à zéro ou à leur capacité maximale, tout en conservant la puissance et le vent sélectionnés pour répéter un scénario.
 
+## Déploiement de prévisualisation
+
+Le laboratoire web dispose d’un workflow GitHub Actions de prévisualisation qui construit le workspace, vérifie TypeScript et les tests, publie `apps/lab/dist` comme artefact et synchronise le contenu statique vers un serveur SSH. Le site est servi à la racine d’un sous-domaine dédié avec une base Vite `/`.
+
+Consultez [`docs/PREVIEW_DEPLOYMENT.md`](docs/PREVIEW_DEPLOYMENT.md) pour la branche `preview`, le déclenchement manuel, les secrets de l’environnement GitHub `preview`, les protections sur le chemin distant et le diagnostic des échecs.
+
 ## Hors périmètre du socle actuel
 
-Le dépôt ne contient pas de pente, altitude, GPX, virages, position latérale, aspiration, plusieurs coureurs, intelligence artificielle, tactique, psychologie, Three.js, scène 3D, Zustand, Web Worker, moteur de corps rigides, collisions, adhérence, sons, sauvegarde, backend, authentification ou déploiement.
+Le dépôt ne contient pas de pente, altitude, GPX, virages, position latérale, aspiration, plusieurs coureurs, intelligence artificielle, tactique, psychologie, Three.js, scène 3D, Zustand, Web Worker, moteur de corps rigides, collisions, adhérence, sons, sauvegarde, backend applicatif ou authentification.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -41,6 +41,14 @@ Contraintes :
 - unités SI dans le moteur ;
 - séparation entre profil physique, profil énergétique, état physique, état énergétique, logique énergétique et orchestration combinée.
 
+## Déploiement de prévisualisation
+
+Le déploiement de prévisualisation du laboratoire est assuré par le workflow GitHub Actions `.github/workflows/deploy-preview.yml`. Il construit le workspace avec Node.js 24 et pnpm 10.28.1, exécute le typecheck, les tests et le build, vérifie `apps/lab/dist/index.html`, publie `apps/lab/dist` comme artefact, puis synchronise le contenu de ce dossier vers un serveur statique par SSH et `rsync`.
+
+Le workflow se déclenche manuellement ou lors d’un push sur la branche longue durée `preview`. Il utilise l’environnement GitHub `preview`, valide la présence des secrets de connexion et refuse un chemin de destination vide, relatif ou égal à `/` avant d’exécuter `rsync --delete`.
+
+Le laboratoire est déployé à la racine d’un sous-domaine dédié. La base Vite reste donc `/`, et aucun chemin de sous-répertoire n’est introduit dans l’application.
+
 ## Scripts racine
 
 - `pnpm install` installe le workspace.

--- a/docs/PREVIEW_DEPLOYMENT.md
+++ b/docs/PREVIEW_DEPLOYMENT.md
@@ -1,0 +1,64 @@
+# Déploiement de prévisualisation du laboratoire
+
+Le laboratoire web dispose d'un workflow GitHub Actions dédié au build et au déploiement statique de prévisualisation. Le site produit est destiné à être servi à la racine d'un sous-domaine dédié, par exemple `https://preview.example.com/`.
+
+## Branche `preview`
+
+La branche longue durée `preview` sert de source automatique pour l'environnement de prévisualisation. Chaque push sur `preview` déclenche le workflow `Deploy Preview Lab` et remplace le contenu distant par le dernier build validé.
+
+Les Pull Requests ne déclenchent pas ce workflow. Les vérifications de Pull Request restent portées par le workflow CI dédié.
+
+## Déclenchement manuel
+
+Le workflow accepte aussi un déclenchement manuel avec `workflow_dispatch` depuis l'interface GitHub Actions. Ce mode permet de reconstruire et redéployer le laboratoire depuis la branche sélectionnée dans GitHub, sans pousser de nouveau commit.
+
+## Environnement et secrets GitHub
+
+Le job utilise l'environnement GitHub `preview`. Les secrets suivants doivent être configurés dans cet environnement :
+
+| Secret | Rôle |
+| --- | --- |
+| `PREVIEW_HOST` | Adresse IP ou nom d'hôte SSH du serveur de prévisualisation. |
+| `PREVIEW_PORT` | Port SSH, généralement `22`. |
+| `PREVIEW_USER` | Utilisateur SSH autorisé à écrire dans le dossier de destination. |
+| `PREVIEW_SSH_KEY` | Clé privée SSH utilisée par GitHub Actions pour la connexion. |
+| `PREVIEW_PATH` | Chemin absolu de destination sur le serveur, par exemple `/var/www/roue-libre-preview`. |
+
+Le workflow vérifie explicitement la présence des cinq secrets avant la connexion SSH. Il vérifie aussi que `PREVIEW_PATH` est un chemin absolu non vide et différent de `/`, afin d'empêcher l'utilisation de `rsync --delete` sur la racine du serveur.
+
+## Dossier produit par Vite
+
+La commande de build du workspace produit le laboratoire statique dans :
+
+```text
+apps/lab/dist
+```
+
+Le workflow vérifie l'existence de `apps/lab/dist/index.html` avant de publier l'artefact et avant le déploiement. Le dossier `dist` reste un artefact de build local ou CI et ne doit pas être commité dans Git.
+
+Le build Vite conserve une base `/`, car le serveur de prévisualisation sert l'application à la racine du sous-domaine et non dans un sous-répertoire.
+
+## Configuration serveur attendue
+
+Le serveur doit :
+
+- accepter une connexion SSH avec l'utilisateur configuré dans `PREVIEW_USER` ;
+- autoriser cet utilisateur à créer et écrire dans `PREVIEW_PATH` ;
+- servir le contenu de `PREVIEW_PATH` comme site statique à la racine du sous-domaine de prévisualisation ;
+- retourner `index.html` et les assets produits par Vite depuis ce même dossier.
+
+Le workflow crée le dossier distant si nécessaire, puis synchronise le contenu de `apps/lab/dist/` vers `PREVIEW_PATH/` avec `rsync -az --delete`. La barre oblique finale sur `apps/lab/dist/` signifie que le contenu du dossier est copié, pas le dossier `dist` lui-même.
+
+## Artefact GitHub Actions
+
+Chaque exécution publie l'artefact `roue-libre-lab-preview` avec une rétention de 7 jours. Cet artefact contient le site statique compilé et permet de récupérer manuellement le build même si la configuration SSH du serveur n'est pas encore opérationnelle.
+
+## Diagnostic d'un échec
+
+- Échec pendant l'installation : vérifier la disponibilité de pnpm `10.28.1`, Node.js `24` et la cohérence de `pnpm-lock.yaml` avec `pnpm install --frozen-lockfile`.
+- Échec de typecheck, tests ou build : reproduire localement avec `pnpm typecheck`, `pnpm test` et `pnpm build`.
+- Échec `apps/lab/dist/index.html` : vérifier que le build Vite du laboratoire produit bien `apps/lab/dist`.
+- Échec de validation des secrets : configurer les cinq secrets dans l'environnement GitHub `preview` et vérifier que `PREVIEW_PATH` est absolu et différent de `/`.
+- Échec `ssh-keyscan` ou SSH : vérifier `PREVIEW_HOST`, `PREVIEW_PORT`, les règles réseau, la clé privée et la présence de la clé publique correspondante dans `authorized_keys` côté serveur.
+- Échec `rsync` : vérifier que `rsync` est disponible côté serveur et que `PREVIEW_USER` peut écrire dans `PREVIEW_PATH`.
+- Site inaccessible après déploiement : vérifier la configuration du serveur web et le pointage du sous-domaine vers le dossier `PREVIEW_PATH`.


### PR DESCRIPTION
### Motivation
- Provide an automated build-and-deploy path for a static preview of the visual laboratory served at the root of a subdomain while preserving the Vite base `/` and not changing any simulation code or behavior.
- Enforce safe deployment by validating required secrets and forbidding dangerous remote paths before using `rsync --delete`.
- Allow manual triggering and an automated flow from a long-lived `preview` branch with controlled concurrency to avoid overlapping deployments.

### Description
- Add `.github/workflows/deploy-preview.yml` implementing a `workflow_dispatch` and `push` on the `preview` branch, `preview` environment binding, concurrency group `preview-deployment`, Node.js 24 and pnpm `10.28.1`, and build/typecheck/test steps that publish `apps/lab/dist` as an artifact named `roue-libre-lab-preview` with 7-day retention.
- Validate presence of `PREVIEW_HOST`, `PREVIEW_PORT`, `PREVIEW_USER`, `PREVIEW_SSH_KEY` and `PREVIEW_PATH` and reject empty, relative or `/` values for `PREVIEW_PATH` before any SSH/`rsync` action.
- Configure SSH securely by writing the private key to a temp file with restrictive permissions, add the host to `known_hosts` via `ssh-keyscan`, create the remote directory if needed, and deploy the content of `apps/lab/dist/` (content-only) using `rsync -az --delete` over SSH.
- Add documentation: update `README.md`, update `docs/ARCHITECTURE.md` and create `docs/PREVIEW_DEPLOYMENT.md` describing branch semantics, triggers, required secrets, produced folder `apps/lab/dist`, server expectations and artifact behavior.

### Testing
- Run `pnpm install` and dependency resolution with pnpm `10.28.1` succeeded (local engine warning only) and the workspace installed successfully.
- Run `pnpm typecheck`, `pnpm test` and `pnpm build` and all typechecks, test suites and production build completed successfully and produced `apps/lab/dist/index.html` as verified with `test -f apps/lab/dist/index.html`.
- Validate workflow syntax and semantics by parsing the YAMLs with Ruby and running `actionlint` (`go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/deploy-preview.yml`) and both checks returned OK.
- No version bump required because the change adds CI automation and documentation without changing distributable code or runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53a107d0a88329be710e7cb1c99637)