### PR TITLE
fix: harden preview deployment validation

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,108 @@
+name: Deploy Preview
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - preview
+
+concurrency:
+  group: preview-deployment
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: preview
+    env:
+      PREVIEW_USER: ${{ secrets.PREVIEW_USER }}
+      PREVIEW_HOST: ${{ secrets.PREVIEW_HOST }}
+      PREVIEW_PORT: ${{ secrets.PREVIEW_PORT }}
+      PREVIEW_PATH: ${{ secrets.PREVIEW_PATH }}
+      PREVIEW_SSH_KEY: ${{ secrets.PREVIEW_SSH_KEY }}
+      PREVIEW_KNOWN_HOSTS: ${{ secrets.PREVIEW_KNOWN_HOSTS }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test
+        run: pnpm test
+
+      - name: Production build
+        run: pnpm build
+
+      - name: Verify lab artifact
+        run: test -f apps/lab/dist/index.html
+
+      - name: Upload lab artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lab-dist
+          path: apps/lab/dist/
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Validate preview deployment settings
+        run: scripts/validate-preview-deployment.sh
+
+      - name: Configure SSH
+        run: |
+          set -euo pipefail
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${PREVIEW_SSH_KEY}" > ~/.ssh/preview_deploy_key
+          chmod 600 ~/.ssh/preview_deploy_key
+          printf '%s\n' "${PREVIEW_KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Resolve remote preview path
+        id: remote-path
+        run: |
+          set -euo pipefail
+          canonical_path="$(ssh -i ~/.ssh/preview_deploy_key -p "${PREVIEW_PORT}" "${PREVIEW_USER}@${PREVIEW_HOST}" \
+            bash -s -- "${PREVIEW_PATH}" <<'REMOTE'
+          set -euo pipefail
+          preview_path="$1"
+          mkdir -p -- "${preview_path}"
+          realpath -- "${preview_path}"
+          REMOTE
+          )"
+          case "${canonical_path}" in
+            /var/www/*) ;;
+            *)
+              echo "::error::Canonical PREVIEW_PATH must be located below /var/www/."
+              exit 1
+              ;;
+          esac
+          if [ "${canonical_path}" = "/var/www" ]; then
+            echo "::error::Canonical PREVIEW_PATH must not be /var/www."
+            exit 1
+          fi
+          if [[ "${canonical_path}" == *$'\n'* || "${canonical_path}" == *$'\r'* || "${canonical_path}" == *$'\t'* || "${canonical_path}" == *' '* ]]; then
+            echo "::error::Canonical PREVIEW_PATH must not contain spaces, tabs, or newlines."
+            exit 1
+          fi
+          printf 'canonical_path=%s\n' "${canonical_path}" >> "${GITHUB_OUTPUT}"
+
+      - name: Deploy lab preview
+        run: |
+          set -euo pipefail
+          rsync -az --delete -e "ssh -i ~/.ssh/preview_deploy_key -p ${PREVIEW_PORT}" \
+            apps/lab/dist/ \
+            "${PREVIEW_USER}@${PREVIEW_HOST}:${{ steps.remote-path.outputs.canonical_path }}/"

--- a/docs/PREVIEW_DEPLOYMENT.md
+++ b/docs/PREVIEW_DEPLOYMENT.md
@@ -1,0 +1,20 @@
+# Déploiement de prévisualisation
+
+Le workflow `deploy-preview.yml` publie le contenu généré de `apps/lab/dist/` vers l'environnement GitHub `preview` lorsque la branche `preview` reçoit un push ou lorsqu'il est lancé manuellement avec `workflow_dispatch`.
+
+## Paramètres requis
+
+Les secrets ou variables d'environnement du déploiement fournissent les paramètres SSH suivants :
+
+- `PREVIEW_USER` : nom d'utilisateur Unix utilisé pour la connexion SSH.
+- `PREVIEW_HOST` : hôte SSH de prévisualisation.
+- `PREVIEW_PORT` : port SSH, entier compris entre `1` et `65 535`.
+- `PREVIEW_PATH` : chemin absolu de destination situé sous `/var/www/`.
+- `PREVIEW_SSH_KEY` : clé privée SSH temporaire utilisée par le workflow.
+- `PREVIEW_KNOWN_HOSTS` : entrée `known_hosts` attendue pour l'hôte de prévisualisation.
+
+## Contraintes de destination
+
+`PREVIEW_PATH` doit commencer par `/var/www/` et désigner un sous-répertoire de `/var/www/`. Les valeurs `/`, `/var` et `/var/www` sont refusées. Le chemin ne contient pas de segment `.` ou `..`, d'espace, de tabulation, de retour à la ligne ou de caractère de contrôle.
+
+Après la création du dossier distant, le workflow résout le chemin avec `realpath` côté serveur et vérifie que le chemin canonique commence par `/var/www/` et n'est pas exactement `/var/www`. La synchronisation `rsync --delete` utilise ce chemin canonique et ne s'exécute pas si cette vérification échoue.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "install:workspace": "pnpm install",
     "typecheck": "pnpm -r typecheck",
-    "test": "pnpm -r test",
+    "test": "scripts/test-preview-deployment-validation.sh && pnpm -r test",
     "dev": "pnpm --filter @rouelibre/lab dev",
     "build": "pnpm -r build"
   },

--- a/scripts/test-preview-deployment-validation.sh
+++ b/scripts/test-preview-deployment-validation.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+validator="${script_dir}/validate-preview-deployment.sh"
+
+run_case() {
+  local expected="$1" path="$2" port="$3"
+  set +e
+  PREVIEW_USER="preview" PREVIEW_HOST="preview.example.com" PREVIEW_PORT="$port" PREVIEW_PATH="$path" PREVIEW_SSH_KEY="test-key" PREVIEW_KNOWN_HOSTS="preview.example.com ssh-ed25519 AAAATEST" "$validator" >/tmp/preview-validation.out 2>/tmp/preview-validation.err
+  local status=$?
+  set -e
+  if [[ "$expected" == "pass" && $status -ne 0 ]]; then
+    echo "Expected pass for path='$path' port='$port'" >&2
+    cat /tmp/preview-validation.err >&2
+    exit 1
+  fi
+  if [[ "$expected" == "fail" && $status -eq 0 ]]; then
+    echo "Expected failure for path='$path' port='$port'" >&2
+    exit 1
+  fi
+}
+
+run_case pass "/var/www/roue-libre-preview" "22"
+run_case pass "/var/www/previews/roue-libre" "65535"
+
+for path in \
+  "/" \
+  "/var" \
+  "/var/www" \
+  "relative/path" \
+  "/tmp/preview" \
+  "/tmp/../.." \
+  "/var/www/roue-libre-preview/../../.." \
+  "/var/www/../root"; do
+  run_case fail "$path" "22"
+done
+
+for port in "0" "65536" "not-a-number"; do
+  run_case fail "/var/www/roue-libre-preview" "$port"
+done

--- a/scripts/validate-preview-deployment.sh
+++ b/scripts/validate-preview-deployment.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+preview_user="${PREVIEW_USER:-}"
+preview_host="${PREVIEW_HOST:-}"
+preview_port="${PREVIEW_PORT:-}"
+preview_path="${PREVIEW_PATH:-}"
+preview_ssh_key="${PREVIEW_SSH_KEY:-}"
+preview_known_hosts="${PREVIEW_KNOWN_HOSTS:-}"
+
+fail() {
+  echo "::error::$1" >&2
+  exit 1
+}
+
+contains_control_tab_newline_or_space() {
+  local value="$1"
+  [[ "$value" == *$'\n'* || "$value" == *$'\r'* || "$value" == *$'\t'* || "$value" == *' '* ]] && return 0
+  LC_ALL=C [[ "$value" == *[$'\001'-$'\010'$'\013'$'\014'$'\016'-$'\037'$'\177']* ]]
+}
+
+contains_control_tab_or_newline() {
+  local value="$1"
+  [[ "$value" == *$'\n'* || "$value" == *$'\r'* || "$value" == *$'\t'* ]] && return 0
+  LC_ALL=C [[ "$value" == *[$'\001'-$'\010'$'\013'$'\014'$'\016'-$'\037'$'\177']* ]]
+}
+
+if [[ -z "$preview_user" ]]; then
+  fail "PREVIEW_USER must not be empty."
+fi
+if contains_control_tab_or_newline "$preview_user"; then
+  fail "PREVIEW_USER must not contain control characters, tabs, or newlines."
+fi
+if [[ ! "$preview_user" =~ ^[a-z_][a-z0-9_-]{0,31}(\$)?$ ]]; then
+  fail "PREVIEW_USER must be a valid Unix-like user name."
+fi
+
+if [[ -z "$preview_ssh_key" ]]; then
+  fail "PREVIEW_SSH_KEY must not be empty."
+fi
+if [[ -z "$preview_known_hosts" ]]; then
+  fail "PREVIEW_KNOWN_HOSTS must not be empty."
+fi
+if contains_control_tab_or_newline "$preview_known_hosts"; then
+  fail "PREVIEW_KNOWN_HOSTS must not contain control characters, tabs, or newlines."
+fi
+
+if [[ -z "$preview_host" ]]; then
+  fail "PREVIEW_HOST must not be empty."
+fi
+if [[ "$preview_host" == -* ]]; then
+  fail "PREVIEW_HOST must not start with '-'."
+fi
+if contains_control_tab_newline_or_space "$preview_host"; then
+  fail "PREVIEW_HOST must not contain spaces, control characters, tabs, or newlines."
+fi
+
+if [[ -z "$preview_port" ]]; then
+  fail "PREVIEW_PORT must not be empty."
+fi
+if [[ ! "$preview_port" =~ ^[0-9]+$ ]] || (( 10#$preview_port < 1 || 10#$preview_port > 65535 )); then
+  fail "PREVIEW_PORT must be an integer between 1 and 65535."
+fi
+
+if [[ -z "$preview_path" ]]; then
+  fail "PREVIEW_PATH must not be empty."
+fi
+if contains_control_tab_newline_or_space "$preview_path"; then
+  fail "PREVIEW_PATH must not contain spaces, control characters, tabs, or newlines."
+fi
+if [[ ! "$preview_path" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  fail "PREVIEW_PATH contains unsupported characters."
+fi
+if [[ "$preview_path" != /* ]]; then
+  fail "PREVIEW_PATH must be absolute."
+fi
+if [[ "$preview_path" == "/" || "$preview_path" == "/var" || "$preview_path" == "/var/www" ]]; then
+  fail "PREVIEW_PATH must be located below /var/www/."
+fi
+case "$preview_path" in
+  /var/www/*) ;;
+  *) fail "PREVIEW_PATH must be located below /var/www/." ;;
+esac
+case "/${preview_path#/}/" in
+  */../*|*/./*) fail "PREVIEW_PATH must not contain . or .. path components." ;;
+esac


### PR DESCRIPTION
### Motivation
- Empêcher des valeurs dangereuses de `PREVIEW_PATH` (chemins relatifs, segments `..`, chemins résolus vers `/` ou hors de `/var/www/`) et garantir qu'on n'exécute jamais `rsync --delete` vers une destination non sûre.
- Valider `PREVIEW_PORT` et les paramètres SSH minimaux pour réduire le risque d'injection ou de mauvaise configuration pendant le déploiement.
- Centraliser la logique de validation pour éviter la duplication entre le workflow et les tests.

### Description
- Ajout du script de validation versionné `scripts/validate-preview-deployment.sh` qui vérifie `PREVIEW_USER`, `PREVIEW_HOST`, `PREVIEW_PORT`, `PREVIEW_PATH`, `PREVIEW_SSH_KEY` et `PREVIEW_KNOWN_HOSTS` selon les contraintes spécifiées (non vide, pas de contrôle/tab/newline, `PREVIEW_PATH` absolu sous `/var/www/`, pas de `.`/`..`, ports dans `1..65535`).
- Ajout d'un test shell `scripts/test-preview-deployment-validation.sh` qui réutilise le validateur pour couvrir chemins acceptés/refusés et ports acceptés/refusés.
- Ajout du workflow `.github/workflows/deploy-preview.yml` qui appelle le validateur avant toute configuration SSH, crée le dossier distant, résout son chemin canonique via `realpath` côté serveur et revérifie que le chemin canonique commence par `/var/www/` et n’est pas exactement `/var/www` avant d’exécuter `rsync --delete`.
- Mise à jour de `package.json` pour exécuter le test shell ajouté avant la suite existante, et ajout de la documentation `docs/PREVIEW_DEPLOYMENT.md` décrivant les contraintes et le comportement de résolution canonique.

### Testing
- `pnpm install` — réussi (locale Node.js a émis un avertissement d’engine, sans impact sur les validations). 
- `pnpm typecheck` — réussi.
- `pnpm test` — réussi; cela a exécuté `scripts/test-preview-deployment-validation.sh` et les suites `vitest` existantes pour `packages/sim-core` et `apps/lab`, toutes passées.
- `pnpm build` — réussi.
- `actionlint` — exécuté localement et sans erreur sur le workflow ajouté.

No version bump required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a53dcb476748329834485fb2123b4a7)