### PR TITLE
Fix docs for constant road grade, restore package versions, and add atomicity tests for non-finite grades

### DIFF
--- a/apps/lab/package.json
+++ b/apps/lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rouelibre/lab",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Organisation interne :
 API exposée :
 
 - `SingleRiderProfile` décrit le couple coureur-vélo avec masses, CdA, coefficient de roulement, rendement mécanique, puissance maximale et limite de force propulsive basse vitesse.
-- `LongitudinalEnvironment` décrit l'air, le vent longitudinal et la gravité.
+- `LongitudinalEnvironment` décrit l'air, la densité de l'air, le vent longitudinal, la gravité et la pente longitudinale constante `roadGrade`. `roadGrade` est exprimée comme un ratio sans unité, positif en montée, négatif en descente et nul par défaut.
 - `SingleRiderState` contient l'état dynamique physique mutable.
 - `createSingleRiderState` crée un état physique initial typé.
 - `computeSingleRiderForces` calcule les forces longitudinales instantanées en utilisant la puissance demandée bornée, pour les usages historiques sans modèle énergétique.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -28,4 +28,4 @@
 
 ## Hors périmètre actuel
 
-Les sujets suivants ne font pas partie du périmètre disponible : altitude issue d'un parcours, profil variable, GPX, virages, aspiration, plusieurs coureurs, intelligence artificielle, tactique, psychologie, scène 3D, Three.js, Zustand, Web Worker, Rapier, collisions, adhérence, sons, sauvegarde, backend, authentification et déploiement.
+Les sujets suivants ne font pas partie du périmètre disponible : altitude issue d'un parcours, profil variable, GPX, virages, aspiration, plusieurs coureurs, intelligence artificielle, tactique, psychologie, scène 3D, Three.js, Zustand, Web Worker, Rapier, collisions, adhérence, sons, sauvegarde, backend et authentification.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rouelibre",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "packageManager": "pnpm@10.28.1",
   "engines": {

--- a/packages/sim-core/package.json
+++ b/packages/sim-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rouelibre/sim-core",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "private": true,
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/sim-core/test/energy.test.ts
+++ b/packages/sim-core/test/energy.test.ts
@@ -354,6 +354,7 @@ describe("single rider energy and physics integration", () => {
     label: string;
     energyProfilePatch?: Partial<SingleRiderEnergyProfile>;
     energyStatePatch?: Partial<SingleRiderEnergyState>;
+    environmentPatch?: Partial<typeof defaultLongitudinalEnvironment>;
     dtSeconds?: number;
     expectedMessage: RegExp;
   }>([
@@ -363,27 +364,52 @@ describe("single rider energy and physics integration", () => {
     { label: "efficiency above one", energyProfilePatch: { recoveryEfficiency: 1.1 }, expectedMessage: /recoveryEfficiency/ },
     { label: "reserve above capacity", energyStatePatch: { anaerobicReserveJoules: 20_001 }, expectedMessage: /anaerobicReserveJoules/ },
     { label: "NaN reserve", energyStatePatch: { anaerobicReserveJoules: Number.NaN }, expectedMessage: /anaerobicReserveJoules/ },
+    { label: "NaN road grade", environmentPatch: { roadGrade: Number.NaN }, expectedMessage: /environment\.roadGrade/ },
+    {
+      label: "positive infinite road grade",
+      environmentPatch: { roadGrade: Number.POSITIVE_INFINITY },
+      expectedMessage: /environment\.roadGrade/,
+    },
+    {
+      label: "negative infinite road grade",
+      environmentPatch: { roadGrade: Number.NEGATIVE_INFINITY },
+      expectedMessage: /environment\.roadGrade/,
+    },
     { label: "invalid dt", dtSeconds: 0, expectedMessage: /dtSeconds/ },
-  ])("rejects invalid configuration without mutating either state: $label", ({ energyProfilePatch, energyStatePatch, dtSeconds, expectedMessage }) => {
-    const physicalState = createSingleRiderState(350);
-    const testedEnergyState = { ...createSingleRiderEnergyState(energyProfile), ...energyStatePatch };
-    const physicalBefore = clonePhysicalState(physicalState);
-    const energyBefore = cloneEnergyState(testedEnergyState);
-    const testedEnergyProfile = { ...energyProfile, ...energyProfilePatch };
+  ])(
+    "rejects invalid configuration without mutating either state: $label",
+    ({ energyProfilePatch, energyStatePatch, environmentPatch, dtSeconds, expectedMessage }) => {
+      const physicalState = createSingleRiderState(350);
+      const testedEnergyState = { ...createSingleRiderEnergyState(energyProfile), ...energyStatePatch };
+      const physicalBefore = clonePhysicalState(physicalState);
+      const energyBefore = cloneEnergyState(testedEnergyState);
+      const testedEnergyProfile = { ...energyProfile, ...energyProfilePatch };
+      const testedEnvironment = { ...defaultLongitudinalEnvironment, ...environmentPatch };
 
-    expect(() => {
-      stepSingleRiderWithEnergy(
-        physicalState,
-        testedEnergyState,
-        physicalProfile,
-        testedEnergyProfile,
-        defaultLongitudinalEnvironment,
-        dtSeconds ?? 1,
-      );
-    }).toThrow(expectedMessage);
-    expect(physicalState).toStrictEqual(physicalBefore);
-    expect(testedEnergyState).toStrictEqual(energyBefore);
-  });
+      expect(() => {
+        stepSingleRiderWithEnergy(
+          physicalState,
+          testedEnergyState,
+          physicalProfile,
+          testedEnergyProfile,
+          testedEnvironment,
+          dtSeconds ?? 1,
+        );
+      }).toThrow(RangeError);
+      expect(() => {
+        stepSingleRiderWithEnergy(
+          physicalState,
+          testedEnergyState,
+          physicalProfile,
+          testedEnergyProfile,
+          testedEnvironment,
+          dtSeconds ?? 1,
+        );
+      }).toThrow(expectedMessage);
+      expect(physicalState).toStrictEqual(physicalBefore);
+      expect(testedEnergyState).toStrictEqual(energyBefore);
+    },
+  );
 });
 
 it("keeps W' evolution independent from road grade for the same produced power sequence", () => {


### PR DESCRIPTION
### Motivation

- Remove contradictory statements about GitHub Pages deployment and make `LongitudinalEnvironment` documentation explicitly include `roadGrade` and air density. 
- Ensure `stepSingleRiderWithEnergy` is atomic when given non-finite `environment.roadGrade` values (`NaN`, `+Infinity`, `-Infinity`).
- Revert unintended version changes in manifests to the previous `0.0.0` value because this PR is about documentation and tests, not release/versioning.

### Description

- Updated `docs/ROADMAP.md` to no longer list deployment as out-of-scope while preserving other out-of-scope items. 
- Completed `docs/ARCHITECTURE.md` to state that `LongitudinalEnvironment` contains air density, longitudinal wind, gravity and the constant longitudinal slope `roadGrade` expressed as a unitless ratio. 
- Extended `packages/sim-core/test/energy.test.ts` invalid-input matrix to include `environment.roadGrade` set to `Number.NaN`, `Number.POSITIVE_INFINITY` and `Number.NEGATIVE_INFINITY`, verifying a `RangeError` mentioning `environment.roadGrade` and that neither physical nor energy state is mutated. 
- Restored `version` to `0.0.0` in `package.json`, `apps/lab/package.json` and `packages/sim-core/package.json`. 

### Testing

- Ran `pnpm install --frozen-lockfile` which completed successfully (with a Node engine warning about local Node version). 
- Ran `pnpm typecheck` which completed successfully. 
- Ran `pnpm test` which completed successfully with all tests passing: total `105` tests passed, including `68` tests in `packages/sim-core` and `37` tests in `apps/lab`. 
- Built the project with `pnpm build` and built the lab with `VITE_BASE_PATH=/rouelibre/ pnpm --filter @rouelibre/lab build`, both succeeding and producing `apps/lab/dist/index.html` with asset paths prefixed by `/rouelibre/`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a548d870c348329b3f3933805b06322)